### PR TITLE
add ability to put methods on any types

### DIFF
--- a/src/ast.lita
+++ b/src/ast.lita
@@ -721,17 +721,17 @@ public func (f: *FuncDecl) getName(name:[MAX_SYMBOL_NAME]char) : bool {
         }
 
         var typeSpec = first.type
+        var prefix = ""
 
         retry:
         if(typeSpec.kind != TypeSpecKind.NAME) {
-            if(typeSpec.kind == TypeSpecKind.PTR) {
-                var ptrSpec = typeSpec
-                typeSpec = ptrSpec.base
-                goto retry;
-            }
-            else if(typeSpec.kind == TypeSpecKind.CONST) {
-                var constSpec = typeSpec
-                typeSpec = constSpec.base
+            if(typeSpec.kind == TypeSpecKind.PTR ||
+               typeSpec.kind == TypeSpecKind.CONST ||
+               typeSpec.kind == TypeSpecKind.ARRAY) {
+                typeSpec = typeSpec.base
+                if(typeSpec.kind == TypeSpecKind.ARRAY) {
+                    prefix = "array_"
+                }
                 goto retry;
             }
             return false
@@ -743,8 +743,11 @@ public func (f: *FuncDecl) getName(name:[MAX_SYMBOL_NAME]char) : bool {
         }
 
         var nameStr = StringInit(name, MAX_SYMBOL_NAME, 0)
-        nameStr.format("%.*s_%.*s",
-            typeSpec.name.length, typeSpec.name.buffer, f.name.str.length, f.name.str.buffer)
+        nameStr.format("%s%.*s_%.*s",
+            prefix,
+            typeSpec.name.length, typeSpec.name.buffer,
+            f.name.str.length, f.name.str.buffer)
+
         return true
     }
 

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -305,6 +305,10 @@ func (this: using *CGen) emitModuleNotes() {
 }
 
 func (this: using *CGen) findSymbolByTypeid(id: Typeid) : *Symbol {
+    if(id < TypeKind.MAX_TYPE_KINDS) {
+        return GetBuiltinSymbol(id)
+    }
+
     var symbols = this.lita.programSymbols.symbolTypes
     for(var i = 0; i < symbols.size(); i += 1) {
         var sym = symbols.get(i)
@@ -340,7 +344,11 @@ func (this: using *CGen) emitTraitForwardDecls() {
                 assert(implSym)
 
                 var implName = this.cTypeName(implSym.type)
-                this.emit("%s %s__to__%s(%s* x);\n", traitName, implName, traitName, implName)
+                this.emit("%s %s__to__%s(%s* x);\n",
+                    traitName,
+                    implName,
+                    traitName,
+                    implName)
             }
         }
         this.emitStrn("\n", 1)

--- a/src/cgen_decl.lita
+++ b/src/cgen_decl.lita
@@ -204,28 +204,25 @@ public func (this: using *CGen) emitAggregateDecl(decl: *AggregateDecl) {
 
     // for traits, we add the virtual table and this pointers
     if(decl.sym.flags & SymbolFlags.IS_TRAIT) {
-        // we only need the virtual table if there are actual implementors of
-        // this trait
-        if(this.lita.programSymbols.interfaceImpls.contains(decl.sym.type.typeid)) {
-            var root = this.lita.programSymbols.root
-            assert(root != null)
+        var root = this.lita.programSymbols.root
+        assert(root != null)
 
-            // we put all generated trait tables in the root module, so therefore we have to manually
-            // name mangle the vtable name
-            var vtableName = [MAX_SYMBOL_NAME]char;
-            var vtableNameStr = StringInit(vtableName, MAX_SYMBOL_NAME, 0)
-            var escapedName = this.escapeNameStr(decl.sym.name)
-            var module = root
+        // we put all generated trait tables in the root module, so therefore we have to manually
+        // name mangle the vtable name
+        var vtableName = [MAX_SYMBOL_NAME]char;
+        var vtableNameStr = StringInit(vtableName, MAX_SYMBOL_NAME, 0)
+        var escapedName = this.escapeNameStr(decl.sym.name)
+        var module = root
 
-            var len = vtableNameStr.format("%s%.*s__%.*s",
-                this.options.cPrefix,
-                module.id.name.length,
-                module.id.name.buffer,
-                escapedName.length,
-                escapedName.buffer)
+        var len = vtableNameStr.format("%s%.*s__%.*s",
+            this.options.cPrefix,
+            module.id.name.length,
+            module.id.name.buffer,
+            escapedName.length,
+            escapedName.buffer)
 
-            this.emit("%s__VirtualTable* __vtable;\n", vtableNameStr.cStr())
-        }
+        this.emit("%s__VirtualTable* __vtable;\n", vtableNameStr.cStr())
+
         this.emitStrn("void* __this;", 13)
     }
     // address bugs that don't allow empty structs/unions

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -60,6 +60,7 @@ public struct TypeChecker {
     pendingValues: Array<*Symbol>
     symbolTypes: Array<*Symbol>     // all types from all modules
     symbolFuncs: Array<*Symbol>
+    symbolTraits: Array<*Symbol>
     mainEntry: *Symbol // main entry point to the program
 
     symbolNotes: Array<*Symbol>
@@ -88,6 +89,7 @@ public func (this: *TypeChecker) init(lita: *Lita) {
     this.pendingValues.init(128, lita.allocator)
     this.symbolTypes.init(256, lita.allocator)
     this.symbolFuncs.init(256, lita.allocator)
+    this.symbolTraits.init(64, lita.allocator)
     this.genericParamStack.init(128, lita.allocator)
     this.genericTemplates.init(64, lita.allocator)
     this.genericContext.callsite = null
@@ -217,7 +219,7 @@ func (this: *TypeChecker) checkTrait(sb: *StringBuffer, a: *TypeInfo, b: *TypeIn
                 return true
             }
         }
-        else if(IsPtrAggregate(b)) {
+        else /*if(IsPtrAggregate(b))*/ {
             var aggInfo = b.getBaseType()
             if(!aggInfo.implementsTrait(aTrait, this)) {
                 sb.appendStrn("'", 1)
@@ -232,14 +234,6 @@ func (this: *TypeChecker) checkTrait(sb: *StringBuffer, a: *TypeInfo, b: *TypeIn
                 sb.appendStr("' trait methods")
                 return true
             }
-        }
-        else {
-            sb.appendStrn("'", 1)
-            b.toString(sb)
-            sb.appendStr(description)
-            a.toString(sb)
-            sb.appendStr("'; only aggregate types can implement traits")
-            return true
         }
     }
 
@@ -288,7 +282,7 @@ func (this: *TypeChecker) checkAssignability(src: SrcPos, a: *TypeInfo, b: *Type
     // comparisons, as they are not as intuitive as other types
     if(IsTraitLike(a)) {
         var aTrait = a.getBaseType()
-        if(!IsPtr(b) && IsAggregate(b)) {
+        if(!IsPtr(b)) {
             var aggInfo = b.getBaseType()
             if(aggInfo.implementsTrait(aTrait, this)) {
                 sb.appendStrn("'", 1)
@@ -343,12 +337,12 @@ func (this: *TypeChecker) checkDeclarability(src: SrcPos, a: *TypeInfo, b: *Type
     return true
 }
 
-func (this: *TypeChecker) checkTypeCompatibility(src: SrcPos, a: *TypeInfo, b: *TypeInfo) : bool {
+func (this: *TypeChecker) checkTypeCompatibility(src: SrcPos, a: *TypeInfo, b: *TypeInfo, allowPtrArithmetic: bool = true) : bool {
     if(a == null || b == null) {
         return false
     }
 
-    if(!a.isAssignable(b, this)) {
+    if(!a.isAssignable(b, this, .allowDecay = true, .allowPtrArithmetic = allowPtrArithmetic)) {
         var sb = StringBufferInit(256, this.allocator)
 
         if(this.checkTrait(sb, a, b, "' is not of type '")) {
@@ -1032,7 +1026,6 @@ func (this: *TypeChecker) implementsTrait(agg: *TypeInfo, iface: *TypeInfo) : bo
 
     var isImpl = matchedCount == numOfTraitFns
     if(isImpl) {
-
         if(!this.interfaceImpls.contains(iface.typeid)) {
             var impls = ArrayInit<Typeid>(32, this.lita.allocator)
             this.interfaceImpls.put(iface.typeid, impls)

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -502,7 +502,7 @@ func (this: *TypeChecker) createDeclSymbol(decl: *Decl) : *Symbol {
             if(funcDecl.flags & FuncFlags.IS_METHOD) {
                 var buffer = [MAX_SYMBOL_NAME]char;
                 if(!funcDecl.getName(buffer)) {
-                    this.result.addError(decl.startPos, "invalid function name")
+                    this.result.addError(decl.startPos, "invalid function name or invalid method caller type")
                     goto err;
                 }
 

--- a/src/checker_decl.lita
+++ b/src/checker_decl.lita
@@ -363,6 +363,10 @@ public func (this: *TypeChecker) resolveAggregateDecl(aggDecl: *AggregateDecl) :
     const isTrait = aggDecl.sym.flags & SymbolFlags.IS_TRAIT
     const module = this.current
 
+    if(isTrait && !(aggDecl.sym.flags & SymbolFlags.IS_GENERIC_TEMPLATE)) {
+        this.symbolTraits.add(aggDecl.sym)
+    }
+
     for(var i = 0; i < aggDecl.fields.size(); i+=1) {
         var field = &aggDecl.fields.elements[i]
 

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -662,8 +662,14 @@ func (this: *TypeChecker) checkFuncCallArgs(expr: *FuncCallExpr, funcType: *Type
 
                 callArg.index = i
 
-                success = this.checkTypeCompatibility(arg.startPos, p, arg.operand.typeInfo) && success
+                success = this.checkTypeCompatibility(arg.startPos, p, arg.operand.typeInfo, .allowPtrArithmetic = false) && success
                 arg.expectedType = p;
+
+                // don't allow for trait casting on rvalues (i.e., prevents &4)
+                if(IsTrait(p) && arg.operand.isRightValue) {
+                    this.errorRvalueAssignmentToTrait(arg, arg.operand.typeInfo, p)
+                    success = false
+                }
             }
         }
 
@@ -708,8 +714,13 @@ func (this: *TypeChecker) checkFuncCallArgs(expr: *FuncCallExpr, funcType: *Type
 
                 var arg = callArg.argExpr
                 callArg.index = paramIndex
-                success = this.checkTypeCompatibility(arg.startPos, p.typeInfo, arg.operand.typeInfo) && success
+                success = this.checkTypeCompatibility(arg.startPos, p.typeInfo, arg.operand.typeInfo, .allowPtrArithmetic = false) && success
                 arg.expectedType = p.typeInfo;
+
+                if(IsTrait(p.typeInfo) && arg.operand.isRightValue) {
+                    this.errorRvalueAssignmentToTrait(arg, arg.operand.typeInfo, p.typeInfo)
+                    success = false
+                }
             }
         }
 
@@ -974,6 +985,12 @@ func (this: *TypeChecker) resolveSubscriptSetExpr(expr: *SubscriptSetExpr) : boo
         return false
     }
 
+    // don't allow for trait casting on rvalues (i.e., prevents &4)
+    if(IsTrait(baseObj) && expr.value.operand.isRightValue) {
+        this.errorRvalueAssignmentToTrait(expr.value, expr.value.operand.typeInfo, baseObj)
+        return false
+    }
+
     expr.operand.typeInfo = expr.value.operand.typeInfo
     return true
 }
@@ -1170,6 +1187,11 @@ func (this: *TypeChecker) checkInitArguments(type: *TypeInfo, expr: *InitExpr) :
             this.checkAssignability(arg.startPos, field.typeInfo, arg.operand.typeInfo, IsDecayable(arg))
             arg.expectedType = field.typeInfo
             arg.value.expectedType = field.typeInfo
+
+            // don't allow for trait casting on rvalues (i.e., prevents &4)
+            if(IsTrait(field.typeInfo) && arg.operand.isRightValue) {
+                this.errorRvalueAssignmentToTrait(arg, arg.operand.typeInfo, field.typeInfo)
+            }
         }
     }
     else if(type.kind == TypeKind.ARRAY) {
@@ -1180,6 +1202,11 @@ func (this: *TypeChecker) checkInitArguments(type: *TypeInfo, expr: *InitExpr) :
             this.checkAssignability(arg.startPos, arrayInfo.arrayOf, arg.operand.typeInfo, IsDecayable(arg))
             arg.expectedType = arrayInfo.arrayOf
             arg.value.expectedType = arrayInfo.arrayOf
+
+            // don't allow for trait casting on rvalues (i.e., prevents &4)
+            if(IsTrait(arrayInfo.arrayOf) && arg.operand.isRightValue) {
+                this.errorRvalueAssignmentToTrait(arg, arg.operand.typeInfo, arrayInfo.arrayOf)
+            }
         }
 
     }
@@ -1345,6 +1372,12 @@ func (this: *TypeChecker) resolveSetExpr(expr: *SetExpr) : bool {
 
     expr.field.operand.typeInfo = field.typeInfo
     expr.operand.typeInfo = field.typeInfo
+
+    // don't allow for trait casting on rvalues (i.e., prevents &4)
+    if(IsTrait(field.typeInfo) && expr.value.operand.isRightValue) {
+        this.errorRvalueAssignmentToTrait(expr.value, expr.value.operand.typeInfo, field.typeInfo)
+        return false
+    }
 
     return this.checkTypeCompatibility(expr.startPos, field.typeInfo, expr.value.operand.typeInfo)
 }
@@ -1835,6 +1868,12 @@ func (this: *TypeChecker) resolveArrayInitExpr(expr: *ArrayInitExpr) : bool {
 
             if(value.operand.typeInfo) {
                 success = this.checkTypeCompatibility(value.startPos, arrayOf, value.operand.typeInfo) && success
+
+                // don't allow for trait casting on rvalues (i.e., prevents &4)
+                if(IsTrait(arrayOf) && value.operand.isRightValue) {
+                    this.errorRvalueAssignmentToTrait(value, value.operand.typeInfo, arrayOf)
+                    success = false
+                }
             }
         }
         return success
@@ -1954,11 +1993,26 @@ func (this: *TypeChecker) resolveBinaryExpr(expr: *BinaryExpr) : bool {
     expr.operand.typeInfo = targetType
     expr.operand.isConst = expr.left.operand.isConst &&
                            expr.right.operand.isConst
+    expr.operand.isRightValue = true
 
     return this.errors() == errors
 
 err:
     return false
+}
+
+func (this: *TypeChecker) errorRvalueAssignmentToTrait(expr: *Expr, type: *TypeInfo, typeTrait: *TypeInfo) {
+    assert(expr != null)
+    assert(type != null)
+
+    var sb = StringBufferInit(256, this.allocator)
+    sb.appendStr("invalid trait assignment from rvalue of type '")
+    type.toString(sb)
+    sb.appendStr("' to trait type '")
+    typeTrait.toString(sb)
+    sb.appendStrn("'", 1)
+
+    this.result.addErrorStr(expr.startPos, sb)
 }
 
 func (this: *TypeChecker) errorNonIndexableType(expr: *Expr, type: *TypeInfo) {

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -1459,7 +1459,7 @@ func (this: *TypeChecker) resolveSizeOfExpr(expr: *SizeOfExpr) : bool {
 func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, type: *TypeInfo) : bool {
     assert(expr != null)
 
-    if(!type) {
+    if(!type || type.kind == TypeKind.FUNC_PTR) {
         return false
     }
 

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -1456,10 +1456,10 @@ func (this: *TypeChecker) resolveSizeOfExpr(expr: *SizeOfExpr) : bool {
     return true
 }
 
-func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, aggInfo: *TypeInfo) : bool {
+func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, type: *TypeInfo) : bool {
     assert(expr != null)
 
-    if(!aggInfo || !IsAggregate(aggInfo)) {
+    if(!type) {
         return false
     }
 
@@ -1487,7 +1487,7 @@ func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, aggInfo: *TypeInfo) : 
         return true;
     }
 
-    var funcSym = aggInfo.getMethod(this.lita.strings, this.current, expr.field.type.name)
+    var funcSym = type.getMethod(this.lita.strings, this.current, expr.field.type.name)
     if(funcSym) {
         var decl = funcSym.decl as (*FuncDecl)
         var typeInfo = funcSym.type;
@@ -1501,7 +1501,7 @@ func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, aggInfo: *TypeInfo) : 
             // We need to update the get expression with the method name
             var oldName = expr.field.type
             var functionName = [MAX_SYMBOL_NAME]char;
-            aggInfo.getFunctionName(functionName, oldName.name)
+            type.getFunctionName(functionName, oldName.name)
 
             expr.field.type.name = this.lita.strings.internCopy(functionName)
         }
@@ -1521,22 +1521,25 @@ func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, aggInfo: *TypeInfo) : 
         return true
     }
 
-    for(var i = 0; i < aggInfo.aggDecl.fields.size(); i += 1) {
-        var field = aggInfo.aggDecl.fields.get(i)
-        if(field.kind == StmtKind.VAR_FIELD_DECL) {
-            var varField = field.varField
-            if(varField.attributes.isUsing) {
-                var baseType = field.typeInfo.getBaseType()
+    if(IsAggregate(type)) {
+        var aggInfo = type
+        for(var i = 0; i < aggInfo.aggDecl.fields.size(); i += 1) {
+            var field = aggInfo.aggDecl.fields.get(i)
+            if(field.kind == StmtKind.VAR_FIELD_DECL) {
+                var varField = field.varField
+                if(varField.attributes.isUsing) {
+                    var baseType = field.typeInfo.getBaseType()
 
-                // avoid inifinite recursion
-                if(baseType.strictEquals(aggInfo)) {
-                    continue
+                    // avoid inifinite recursion
+                    if(baseType.strictEquals(aggInfo)) {
+                        continue
+                    }
+
+                    if(this.checkMethodExpr(expr, baseType)) {
+                        return true
+                    }
+
                 }
-
-                if(this.checkMethodExpr(expr, baseType)) {
-                    return true
-                }
-
             }
         }
     }
@@ -1558,8 +1561,15 @@ func (this: *TypeChecker) resolveGetExpr(expr: *GetExpr) : bool {
 
     var objectTypeInfo = expr.object.operand.typeInfo
     if(!IsFieldAccessible(objectTypeInfo)) {
-        this.errorNoFieldAccess(expr.object, objectTypeInfo, expr.field.type.name)
-        return false
+
+        // for primitive types, only check and see if there is
+        // a method defined for field access
+        var info = objectTypeInfo.getBaseType()
+        if(!this.checkMethodExpr(expr, info)) {
+            this.errorNoFieldAccess(expr.object, objectTypeInfo, expr.field.type.name)
+            return false
+        }
+        return true
     }
 
     if(objectTypeInfo.kind == TypeKind.ENUM) {

--- a/src/error_codes.lita
+++ b/src/error_codes.lita
@@ -110,7 +110,7 @@ public func PrintError(sb: *StringBuffer, error: PhaseError) {
         sb.append("%s\n", error.message)
         return;
     }
-
+// TODO: Account for TABS in source code, the alignment is off when tabs are present.
     sb.append("%s:%d:%d error: %s\n", error.pos.filename, error.pos.lineNumber, error.pos.position, error.message)
     sb.append("%.*s\n", error.pos.getLineLength(), error.pos.lineStart)
     var spaceCount = 0

--- a/src/lsp/workspace.lita
+++ b/src/lsp/workspace.lita
@@ -351,40 +351,14 @@ public func (this: *Workspace) references(uri: *const char, position: *JsonNode,
             case StmtKind.GET_EXPR: {
                 var expr = location.node as (*GetExpr)
                 var base = expr.object.operand.typeInfo.getBaseType()
+
+                // if aggregate, check aggregate fields
                 if(IsAggregate(base)) {
                     var aggInfo = base
                     var fieldResult = aggInfo.getFieldPosition(expr.field.type.name)
                     this.lsp.log("Getting field position: %d\n", fieldResult.position)
                     if(fieldResult.aggInfo) {
                         return this.findFieldReferences(fieldResult.aggInfo.typeid, fieldResult.position, alloc)
-                    }
-
-                    // This might be a method call, we must check all functions in the entire program
-                    // for the method declaration
-                    else {
-                        // use the field operand vs. the field.sym because it's the one that always
-                        // gets resolved in the type checker phase
-                        if(!expr.field.operand.typeInfo) {
-                            break
-                        }
-
-                        var fieldType = expr.field.operand.typeInfo.typeid
-
-                        for(var i = 0; i < this.lsp.lita.programSymbols.symbolFuncs.size(); i += 1) {
-                            var fn = this.lsp.lita.programSymbols.symbolFuncs.get(i)
-                            if(!(fn.flags & SymbolFlags.IS_METHOD)) {
-                                continue
-                            }
-
-                            if(fn.type.typeid == fieldType) {
-                                /*this.lsp.log("Found reference symbol: %s %llu vs. %llu\n", fn.name, fn.type.typeid, fieldType)
-                                for(var i = 0; i < this.lsp.lita.references.typeReferences.size(); i+= 1) {
-                                    var ref = this.lsp.lita.references.typeReferences.get(i)
-                                    this.lsp.log("TypeId: %llu\n", ref.type)
-                                }*/
-                                return this.findTypeReferences(fn.type.typeid, alloc)
-                            }
-                        }
                     }
                 }
                 else if (base.kind == TypeKind.ENUM) {
@@ -393,6 +367,28 @@ public func (this: *Workspace) references(uri: *const char, position: *JsonNode,
                     this.lsp.log("Getting enum position: %d\n", index)
                     return this.findFieldReferences(enumInfo.typeid, index, alloc)
                 }
+
+                // This might be a method call, we must check all functions in the entire program
+                // for the method declaration
+                // use the field operand vs. the field.sym because it's the one that always
+                // gets resolved in the type checker phase
+                if(!expr.field.operand.typeInfo) {
+                    break
+                }
+
+                var fieldType = expr.field.operand.typeInfo.typeid
+
+                for(var i = 0; i < this.lsp.lita.programSymbols.symbolFuncs.size(); i += 1) {
+                    var fn = this.lsp.lita.programSymbols.symbolFuncs.get(i)
+                    if(!(fn.flags & SymbolFlags.IS_METHOD)) {
+                        continue
+                    }
+
+                    if(fn.type.typeid == fieldType) {
+                        return this.findTypeReferences(fn.type.typeid, alloc)
+                    }
+                }
+
                 break
             }
             case StmtKind.SET_EXPR: {
@@ -671,30 +667,6 @@ public func (this: *Workspace) goToDefinition(uri: *const char, position: *JsonN
                             }
                         }
                     }
-                    // This might be a method call, we must check all functions in the entire program
-                    // for the method declaration
-                    else {
-
-                        // use the field operand vs. the field.sym because it's the one that always
-                        // gets resolved in the type checker phase
-                        if(!expr.field.operand.typeInfo) {
-                            break
-                        }
-
-                        var fieldType = expr.field.operand.typeInfo.typeid
-
-                        for(var i = 0; i < this.lsp.lita.programSymbols.symbolFuncs.size(); i += 1) {
-                            var fn = this.lsp.lita.programSymbols.symbolFuncs.get(i)
-                            if(!(fn.flags & SymbolFlags.IS_METHOD)) {
-                                continue
-                            }
-
-                            if(fn.type.typeid == fieldType) {
-                                var decl = fn.decl
-                                return SrcPosWithEndToLocation(decl.startPos, decl.endPos, this.rootPath, alloc)
-                            }
-                        }
-                    }
                 }
                 else if (base.kind == TypeKind.ENUM) {
                     var enumInfo = base
@@ -702,6 +674,28 @@ public func (this: *Workspace) goToDefinition(uri: *const char, position: *JsonN
                     if(index >= 0) {
                         var entryDecl = enumInfo.enumDecl.fields.get(index)
                         return SrcPosWithEndToLocation(entryDecl.startPos, entryDecl.endPos, this.rootPath, alloc)
+                    }
+                }
+
+                // This might be a method call, we must check all functions in the entire program
+                // for the method declaration
+                // use the field operand vs. the field.sym because it's the one that always
+                // gets resolved in the type checker phase
+                if(!expr.field.operand.typeInfo) {
+                    break
+                }
+
+                var fieldType = expr.field.operand.typeInfo.typeid
+
+                for(var i = 0; i < this.lsp.lita.programSymbols.symbolFuncs.size(); i += 1) {
+                    var fn = this.lsp.lita.programSymbols.symbolFuncs.get(i)
+                    if(!(fn.flags & SymbolFlags.IS_METHOD)) {
+                        continue
+                    }
+
+                    if(fn.type.typeid == fieldType) {
+                        var decl = fn.decl
+                        return SrcPosWithEndToLocation(decl.startPos, decl.endPos, this.rootPath, alloc)
                     }
                 }
                 break

--- a/src/module.lita
+++ b/src/module.lita
@@ -121,6 +121,19 @@ func AddBuiltin(lita: *Lita, type: *TypeInfo) {
     type.sym = sym
 }
 
+public func GetBuiltinSymbol(typeid: Typeid) : *Symbol {
+    if(typeid >= TypeKind.MAX_TYPE_KINDS) {
+        return null
+    }
+
+    var typeInfo = BUILTIN_TYPES[typeid]
+    if(!typeInfo) {
+        return null
+    }
+
+    return typeInfo.sym
+}
+
 public func NewModule(lita: *Lita,
                       filename: *const char) : *Module {
 
@@ -179,6 +192,10 @@ public func (this: *Module) initIncrementalBuild() {
             continue
         }
     }
+}
+
+public func (this: *Module) isBuiltin() : bool {
+    return this == &builtins
 }
 
 public func (this: *Module) postIncrementalBuild() {

--- a/src/traits.lita
+++ b/src/traits.lita
@@ -91,163 +91,204 @@ C:
 public func CreateTraitWrappers(checker: *TypeChecker) : Array<*Decl> {
     var allocator = checker.current.allocator
 
-    var decls = ArrayInit<*Decl>(512, allocator)
     var sb = StringBufferInit(2048, allocator)
 
-    //var traitNameBuffer: [MAX_SYMBOL_NAME]char;
     var traitBuffer      = StringBufferInit(MAX_SYMBOL_NAME, allocator)
     var traitFieldBuffer = StringBufferInit(MAX_SYMBOL_NAME, allocator)
 
-    sb.append("// %d number of traits found.\n", checker.interfaceImpls.size())
-    for(var it = checker.interfaceImpls.iter(); it.hasNext();) {
-        var entry = it.next()
-        var traitSym = FindSymbolByTypeid(checker.symbolTypes, entry.key)
+    for(var i = 0; i < checker.symbolTraits.size(); i+=1) {
+        var traitSym = checker.symbolTraits.get(i)
         assert(traitSym)
         assert(traitSym.decl && traitSym.decl.kind == StmtKind.TRAIT_DECL)
 
         var traitDecl = traitSym.decl as (*AggregateDecl)
         var traitName = GetTraitName(traitSym, traitBuffer)
+        GenerateVTable(traitSym, traitDecl, traitName, sb)
 
-        sb.append("// Trait: '%.*s' has %d impls\n", traitDecl.name.str.length, traitDecl.name.str.buffer, entry.value.size())
-        // Generate VTable
-        {
-            //sb.append("@module(\"%s\")\n", traitSym.declared.id.filename)
-           // printf("Sym: %s vs %s\n", traitName, traitDecl.name.asString())
-            sb.append("@hidden struct %.*s__VirtualTable", traitName.length, traitName.buffer)
+        // there are no implementations, so we can skip generating wrappers
+        // for this trait
+        if(!checker.interfaceImpls.contains(traitSym.type.typeid)) {
+            continue
+        }
+
+        var impls = checker.interfaceImpls.getPtr(traitSym.type.typeid)
+        GenerateWrapperFunctions(
+            checker,
+            traitSym,
+            traitDecl,
+            traitName,
+            sb,
+            traitFieldBuffer,
+            impls)
+
+        GenerateVTableEntries(
+            checker,
+            traitDecl,
+            traitName,
+            sb,
+            traitFieldBuffer,
+            impls)
+    }
+
+    //printf("Traits Source: \n%s\n", sb.cStr())
+    var parser = ParserInit("generated", sb.cStr(), sb.length, checker.current, checker.lita)
+    var stmts = parser.parseModule()
+    return stmts.declarations
+}
+
+func GenerateVTable(
+        traitSym: *Symbol,
+        traitDecl: *AggregateDecl,
+        traitName: StringView,
+        sb: *StringBuffer) {
+    sb.append("@hidden struct %.*s__VirtualTable", traitName.length, traitName.buffer)
+    sb.append(" {\n")
+
+    for(var j = 0; j < traitDecl.fields.size(); j += 1) {
+            var field = traitDecl.fields.get(j)
+            assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
+            assert(field.typeInfo != null && field.typeInfo.kind == TypeKind.FUNC_PTR)
+
+            var fn = field.typeInfo
+            var traitField = field.traitField
+            sb.append("    %.*s: func", traitField.name.str.length, traitField.name.str.buffer)
+            PrintGenerics(fn.genericParams, sb)
+            sb.append("(*void")
+            for(var p = 0; p < fn.paramDecls.size(); p += 1) {
+                var param = fn.paramDecls.get(p)
+                sb.append(", ")
+                param.toString(sb)
+            }
+            sb.append(") : ")
+            fn.returnType.toString(sb)
+            sb.append(";\n")
+    }
+    sb.append("}\n")
+}
+
+
+func GenerateWrapperFunctions(
+        checker: *TypeChecker,
+        traitSym: *Symbol,
+        traitDecl: *AggregateDecl,
+        traitName: StringView,
+        sb: *StringBuffer,
+        traitFieldBuffer: *StringBuffer,
+        impls: *Array<Typeid>) {
+    sb.append("// Trait: '%.*s' has %d impls\n", traitDecl.name.str.length, traitDecl.name.str.buffer, impls.size())
+
+    // Generate Wrapper functions
+    for(var i = 0; i < impls.size(); i += 1) {
+        var implSym = FindSymbolByTypeid(checker.symbolTypes, impls.get(i))
+
+        if(!implSym) {
+            continue;
+        }
+
+        var implEscapedName = GetTraitName(implSym, traitFieldBuffer)
+
+        var implName = implSym.name
+
+        if(implSym.flags & SymbolFlags.IS_FROM_GENERIC_TEMPLATE) {
+            var genericTypeid = implSym.type.genericTypeid
+            var genSym = FindSymbolByTypeid(checker.symbolTypes, genericTypeid)
+            implName = genSym.name
+        }
+
+        for(var j = 0; j < traitDecl.fields.size(); j += 1) {
+            var field = traitDecl.fields.get(j)
+            assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
+            assert(field.typeInfo && field.typeInfo.kind == TypeKind.FUNC_PTR)
+
+            var fn = field.typeInfo
+
+            sb.append("@hidden func __%.*s_%.*s_wrapper", implEscapedName.length, implEscapedName.buffer, field.traitField.name.str.length, field.traitField.name.str.buffer)
+            sb.append("(this: *void")
+            for(var p = 0; p < fn.paramDecls.size(); p += 1) {
+                var param = fn.paramDecls.get(p)
+                sb.append(", _%d: ", p)
+                param.toString(sb)
+            }
+
+            if(fn.hasVarargs) {
+                // TODO: do varargs passing
+                sb.append(", ...")
+            }
+
+            sb.append(") : ")
+            fn.returnType.toString(sb)
             sb.append(" {\n")
+            {
+                if(implSym.declared.isBuiltin()) {
+                    sb.append("    var __this = this as (*%.*s", implName.length, implName.buffer)
+                }
+                else {
+                    var moduleName = implSym.declared.id.name
+                    sb.append("    var __this = this as (*%.*s::%.*s",
+                        moduleName.length, moduleName.buffer,
+                        implName.length, implName.buffer)
+                }
+                PrintGenericArgs(implSym.genericArgs, sb)
+                sb.append(")\n")
 
+                if(fn.returnType.kind != TypeKind.VOID) {
+                    sb.append("    return ")
+                }
+                else {
+                    sb.append("    ")
+                }
+
+                sb.append("__this.%.*s", field.traitField.name.str.length, field.traitField.name.str.buffer)
+
+                sb.append("(")
+                for(var p = 0; p < fn.paramDecls.size(); p += 1) {
+                    var param = fn.paramDecls.get(p)
+                    if(p > 0) {
+                        sb.append(", ")
+                    }
+                    sb.append("_%d", p)
+                }
+                sb.append(")")
+            }
+            sb.append("\n}\n")
+        }
+    }
+}
+
+func GenerateVTableEntries(
+        checker: *TypeChecker,
+        traitDecl: *AggregateDecl,
+        traitName: StringView,
+        sb: *StringBuffer,
+        traitFieldBuffer: *StringBuffer,
+        impls: *Array<Typeid>) {
+
+    sb.append("@hidden const %.*s__vtables = []*%.*s__VirtualTable {\n",
+        traitName.length, traitName.buffer, traitName.length, traitName.buffer)
+
+    for(var i = 0; i < impls.size(); i += 1) {
+        var implSym = FindSymbolByTypeid(checker.symbolTypes, impls.get(i))
+        if(!implSym) {
+            continue
+        }
+
+        var implEscapedName = GetTraitName(implSym, traitFieldBuffer)
+        sb.append("    [%d] = &%.*s__VirtualTable {\n", i, traitName.length, traitName.buffer)
+        {
             for(var j = 0; j < traitDecl.fields.size(); j += 1) {
-                  var field = traitDecl.fields.get(j)
-                  assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
-                  assert(field.typeInfo != null && field.typeInfo.kind == TypeKind.FUNC_PTR)
+                var field = traitDecl.fields.get(j)
+                assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
 
-                  var fn = field.typeInfo
-                  var traitField = field.traitField
-                  sb.append("    %.*s: func", traitField.name.str.length, traitField.name.str.buffer)
-                  PrintGenerics(fn.genericParams, sb)
-                  sb.append("(*void")
-                  for(var p = 0; p < fn.paramDecls.size(); p += 1) {
-                      var param = fn.paramDecls.get(p)
-                      sb.append(", ")
-                      param.toString(sb)
-                  }
-                  sb.append(") : ")
-                  fn.returnType.toString(sb)
-                  sb.append(";\n")
-            }
-            sb.append("}\n")
-        }
-
-        // Generate Wrapper functions
-        {
-            for(var i = 0; i < entry.value.size(); i += 1) {
-                var implSym = FindSymbolByTypeid(checker.symbolTypes, entry.value.get(i))
-
-                if(!implSym) {
-                    continue;
-                }
-
-                var implEscapedName = GetTraitName(implSym, traitFieldBuffer)
-
-                var implName = implSym.name
-
-                if(implSym.flags & SymbolFlags.IS_FROM_GENERIC_TEMPLATE) {
-                    var genericTypeid = implSym.type.genericTypeid
-                    var genSym = FindSymbolByTypeid(checker.symbolTypes, genericTypeid)
-                    implName = genSym.name
-                }
-
-                for(var j = 0; j < traitDecl.fields.size(); j += 1) {
-                    var field = traitDecl.fields.get(j)
-                    assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
-                    assert(field.typeInfo && field.typeInfo.kind == TypeKind.FUNC_PTR)
-
-                    var fn = field.typeInfo
-
-                    sb.append("@hidden func __%.*s_%.*s_wrapper", implEscapedName.length, implEscapedName.buffer, field.traitField.name.str.length, field.traitField.name.str.buffer)
-                    sb.append("(this: *void")
-                    for(var p = 0; p < fn.paramDecls.size(); p += 1) {
-                        var param = fn.paramDecls.get(p)
-                        sb.append(", _%d: ", p)
-                        param.toString(sb)
-                    }
-
-                    if(fn.hasVarargs) {
-                        // TODO: do varargs passing
-                        sb.append(", ...")
-                    }
-
-                    sb.append(") : ")
-                    fn.returnType.toString(sb)
-                    sb.append(" {\n")
-                    {
-                        var moduleName = implSym.declared.id.name
-                        sb.append("    var __this = this as (*%.*s::%.*s", moduleName.length, moduleName.buffer, implName.length, implName.buffer)
-                        PrintGenericArgs(implSym.genericArgs, sb)
-                        sb.append(")\n")
-
-                        if(fn.returnType.kind != TypeKind.VOID) {
-                            sb.append("    return ")
-                        }
-                        else {
-                            sb.append("    ")
-                        }
-
-                        sb.append("__this.%.*s", field.traitField.name.str.length, field.traitField.name.str.buffer)
-
-                        sb.append("(")
-                        for(var p = 0; p < fn.paramDecls.size(); p += 1) {
-                            var param = fn.paramDecls.get(p)
-                            if(p > 0) {
-                                sb.append(", ")
-                            }
-                            sb.append("_%d", p)
-                        }
-                        sb.append(")")
-                    }
-                    sb.append("\n}\n")
-                }
+                sb.append("        .%.*s = __%.*s_%.*s_wrapper",
+                    field.traitField.name.str.length, field.traitField.name.str.buffer,
+                    implEscapedName.length, implEscapedName.buffer,
+                    field.traitField.name.str.length, field.traitField.name.str.buffer)
+                sb.append(",\n")
             }
         }
-
-        // Generate Vtables implementations
-        {
-            //sb.append("@module(\"%s\")\n", traitSym.declared.id.filename)
-            sb.append("@hidden const %.*s__vtables = []*%.*s__VirtualTable {\n",
-                traitName.length, traitName.buffer, traitName.length, traitName.buffer)
-
-            for(var i = 0; i < entry.value.size(); i += 1) {
-                var implSym = FindSymbolByTypeid(checker.symbolTypes, entry.value.get(i))
-                assert(implSym)
-
-                var implEscapedName = GetTraitName(implSym, traitFieldBuffer)
-                sb.append("    [%d] = &%.*s__VirtualTable {\n", i, traitName.length, traitName.buffer)
-                {
-                    for(var j = 0; j < traitDecl.fields.size(); j += 1) {
-                        var field = traitDecl.fields.get(j)
-                        assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
-
-                        sb.append("        .%.*s = __%.*s_%.*s_wrapper",
-                            field.traitField.name.str.length, field.traitField.name.str.buffer,
-                            implEscapedName.length, implEscapedName.buffer,
-                            field.traitField.name.str.length, field.traitField.name.str.buffer)
-                        sb.append(",\n")
-                    }
-                }
-                sb.append("    },\n")
-            }
-            sb.append("}\n")
-        }
+        sb.append("    },\n")
     }
-
-    {
-        //printf("Traits Source: \n%s\n", sb.cStr())
-        var parser = ParserInit("generated", sb.cStr(), sb.length, checker.current, checker.lita)
-        var stmts = parser.parseModule()
-        decls.addAll(stmts.declarations)
-    }
-
-    return decls
+    sb.append("}\n")
 }
 
 func PrintGenerics(genericParams: *Array<GenericParam>, sb: *StringBuffer) {
@@ -285,6 +326,10 @@ func PrintGenericArgs(genericArgs: *Array<*TypeInfo>, sb: *StringBuffer) {
 }
 
 func FindSymbolByTypeid(symbols: Array<*Symbol>, id: Typeid) : *Symbol {
+    if(id < TypeKind.MAX_TYPE_KINDS) {
+        return GetBuiltinSymbol(id)
+    }
+
     for(var i = 0; i < symbols.size(); i += 1) {
         var sym = symbols.get(i)
         if(sym.type && sym.type.typeid == id) {

--- a/src/types.lita
+++ b/src/types.lita
@@ -2058,15 +2058,12 @@ public func (this: *TypeInfo) getMethod(strings: *Strings, module: *Module, meth
 }
 
 public func (this: *TypeInfo) implementsTrait(iface : *TypeInfo, checker: *TypeChecker) : bool {
-    //printf("Here for this: %s iface: %s\n", this.toStringDebug(), iface.toStringDebug())
     if(!IsAggregateLike(iface)) {
-       // printf("iface %s not an aggregate\n", iface.toStringDebug())
         return false
     }
 
     var aggIface = AsAggregate(iface)
     if(!aggIface.sym || !(aggIface.sym.flags & SymbolFlags.IS_TRAIT)) {
-       // printf("iface %s not an interface\n", iface.toStringDebug())
         return false
     }
 

--- a/src/types.lita
+++ b/src/types.lita
@@ -686,7 +686,12 @@ public func (this: *TypeInfo) strictEquals(other: *TypeInfo) : bool {
     return false
 }
 
-public func (this: *TypeInfo) isAssignable(other: *TypeInfo, checker: *TypeChecker, allowDecay: bool = true) : bool {
+public func (this: *TypeInfo) isAssignable(
+        other: *TypeInfo,
+        checker: *TypeChecker,
+        allowDecay: bool = true,
+        allowPtrArithmetic: bool = true) : bool {
+
     assert(this != null)
     assert(other != null)
 
@@ -756,7 +761,7 @@ public func (this: *TypeInfo) isAssignable(other: *TypeInfo, checker: *TypeCheck
 
         case TypeKind.STR: {
             // Allow for pointer arithmetic
-            if(IsInteger(other)) {
+            if(allowPtrArithmetic && IsInteger(other)) {
                 return true
             }
             return this.isDeclarable(other, checker)
@@ -764,7 +769,7 @@ public func (this: *TypeInfo) isAssignable(other: *TypeInfo, checker: *TypeCheck
         case TypeKind.ARRAY: {
 
             // Allow for pointer arithmetic
-            if(IsInteger(other)) {
+            if(allowPtrArithmetic && IsInteger(other)) {
                 return true
             }
 
@@ -777,7 +782,7 @@ public func (this: *TypeInfo) isAssignable(other: *TypeInfo, checker: *TypeCheck
         }
         case TypeKind.PTR: {
             // Allow for pointer arithmetic
-            if(IsInteger(other)) {
+            if(allowPtrArithmetic && IsInteger(other)) {
                 return true
             }
             return this.isDeclarable(other, checker)
@@ -1170,7 +1175,7 @@ public func (this: *TypeInfo) isDeclarable(other: *TypeInfo, checker: *TypeCheck
                 return true
             }
 
-            if(!IsPtrAggregate(other)) {
+            if(!IsPtr(other)) {
                 return false
             }
 
@@ -1339,7 +1344,7 @@ public func IsFuncImpl(traitFn: *TypeInfo, fn: *TypeInfo, checker: *TypeChecker)
 
     // first parameter must be a pointer
     var firstArg = funcInfo.funcDecl.params.get(0).typeInfo
-    if(!IsPtrAggregate(firstArg)) {
+    if(!IsPtr(firstArg)) {
         return false
     }
 
@@ -2148,54 +2153,6 @@ public struct TypeInfo {
     }
 }
 
-/*
-public struct GenericTypeInfo {
-    typeInfo: using TypeInfo
-    genericTypeid: Typeid       // The typeid of the original Generic Template
-}
-
-public struct FuncTypeInfo {
-    info: using GenericTypeInfo
-    returnType: *TypeInfo
-    decl: *FuncDecl
-}
-
-public struct ConstTypeInfo {
-    info: using TypeInfo
-    constOf: *TypeInfo
-}
-
-public struct PtrTypeInfo {
-    info: using TypeInfo
-    ptrOf: *TypeInfo
-}
-
-public struct ArrayTypeInfo {
-    info: using TypeInfo
-    arrayOf: *TypeInfo
-    length: usize
-    numOfElements: *Expr
-    isLengthDefined: bool
-}
-
-public struct FuncPtrTypeInfo {
-    info: using GenericTypeInfo
-    genericParams: Array<GenericParam>
-    returnType: *TypeInfo
-    paramDecls: Array<*TypeInfo>
-    hasVarargs: bool
-    isTrait: bool
-}
-
-public struct EnumTypeInfo {
-    info: using TypeInfo
-    decl: *EnumDecl
-}
-
-public struct AggregateTypeInfo {
-    info: using GenericTypeInfo
-    decl: *AggregateDecl
-}*/
 
 public const BOOL_TYPE = TypeInfo {
     .kind = TypeKind.BOOL,
@@ -2297,4 +2254,24 @@ public const POISON_TYPE = TypeInfo {
     .kind = TypeKind.POISON,
     .typeid = TypeKind.POISON as (Typeid),
     .sym = null
+}
+
+public const BUILTIN_TYPES = [TypeKind.MAX_TYPE_KINDS]*TypeInfo {
+    [TypeKind.BOOL] = &BOOL_TYPE,
+    [TypeKind.CHAR] = &CHAR_TYPE,
+    [TypeKind.I8] = &I8_TYPE,
+    [TypeKind.U8] = &U8_TYPE,
+    [TypeKind.I16] = &I16_TYPE,
+    [TypeKind.U16] = &U16_TYPE,
+    [TypeKind.I32] = &I32_TYPE,
+    [TypeKind.U32] = &U32_TYPE,
+    [TypeKind.I64] = &I64_TYPE,
+    [TypeKind.U64] = &U64_TYPE,
+    [TypeKind.F32] = &F32_TYPE,
+    [TypeKind.F64] = &F64_TYPE,
+    [TypeKind.USIZE] = &USIZE_TYPE,
+    [TypeKind.NULL] = &NULL_TYPE,
+    [TypeKind.VOID] = &VOID_TYPE,
+    [TypeKind.STR] = &STR_TYPE,
+    [TypeKind.POISON] = &POISON_TYPE,
 }

--- a/test/tests/methods.json
+++ b/test/tests/methods.json
@@ -626,5 +626,73 @@
                 assert(t.a() == 4)
             `,
         },
+
+        {
+            "name": "Method definition on i32",
+            "definitions": `
+                func (this: i32) add(other: i32) : i32 {
+                    return this + other
+                }
+            `,
+            "code": `
+                assert(4_i32.add(5) == 9)
+            `,
+        },
+        {
+            "name": "Method definition on f32",
+            "definitions": `
+                func (this: f32) add(other: f32) : f32 {
+                    return this + other
+                }
+            `,
+            "code": `
+                assert(4_f32.add(5_f32) == 9_f32)
+            `,
+        },
+        {
+            "name": "Method definition on bool",
+            "definitions": `
+                func (this: bool) flip() : bool {
+                    return !this
+                }
+            `,
+            "code": `
+                assert(true.flip() == false)
+                assert(false.flip() == true)
+            `,
+        },
+        {
+            "name": "Method definition on str",
+            "definitions": `
+                func (this: *const char) indexAt(i: i32) : char {
+                    return this[i]
+                }
+            `,
+            "code": `
+                assert("hello".indexAt(1) == 'e')
+            `,
+        },
+        {
+            "name": "Method definition on array",
+            "definitions": `
+                func (this: [4]i32) indexAt(i: i32) : char {
+                    return this[i]
+                }
+            `,
+            "code": `
+                assert([4]i32{0,4,6,8}.indexAt(1) == 4)
+            `,
+        },
+        {
+            "name": "Method definition on char",
+            "definitions": `
+                func (this: char) isLowerCase() : bool {
+                    return this >= 97 && this <= 122
+                }
+            `,
+            "code": `
+                assert('a'.isLowerCase() == true)
+            `,
+        },
     ]
 }

--- a/test/tests/single.json
+++ b/test/tests/single.json
@@ -38,6 +38,263 @@
                 assert(function.fn(1) == 5)
             `,
         },
+        {
+            "name" : "Traits With Generics with Default Methods",
+            "definitions": `
+
+                trait Function<T> {
+                    fn: func(T) : T
+                }
+
+                func (this: Function<T>) test<T>(x: T) : T {
+                    return this.fn<T>(x)
+                }
+
+                struct FunctionImpl {
+                    i: i32
+                }
+
+                func (this: *FunctionImpl) fn(i: i32) : i32 {
+                    return this.i + i
+                }
+            `,
+            "code": `
+                var impl = FunctionImpl {
+                    .i = 4
+                }
+
+                var function: Function<i32> = &impl
+                assert(function.fn(1) == 5)
+                assert(function.test(1) == 5)
+            `,
+        },
+        {
+            "name" : "Traits with Default Methods",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: Adder) subAdd(a: i32) : i32 {
+                    var x = this.add(a)
+                    var result = this.sub(x)
+                    return result
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var x = 10
+                var adder: Adder = &x;
+                assert(adder.add(4) == 14)
+                assert(adder.sub(4) == 6)
+                assert(adder.subAdd(2) == -2)
+            `,
+        },
+        {
+            "name" : "Traits with Default Methods with no Impls",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: Adder) subAdd(a: i32) : i32 {
+                    var x = this.add(a)
+                    var result = this.sub(x)
+                    return result
+                }
+            `,
+            "code": `
+
+            `,
+        },
+        {
+            "name" : "Traits invalid assignment to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder: Adder = &4
+            `,
+            "error": "lvalue required as unary '&' operand"
+        },
+        {
+            "name" : "Traits invalid function argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+
+                func Test(adder: Adder) : i32 {
+                    return adder.add(4)
+                }
+            `,
+            "code": `
+                Test(4)
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid init argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = AdderImpl {
+                    .adder = 4
+                }
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array init argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adders:[4]Adder = [4]Adder{
+                    [0] = 4
+                }
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid aggregate argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = AdderImpl{}
+                adder.adder = 4
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = [4]Adder{}
+                adder[0] = 4
+            `,
+            "error": "'i32' is not of type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = [4]Adder{}
+                adder[0] = &4
+            `,
+            "error": "lvalue required as unary '&' operand"
+        },
 /*
         {
             "name": "struct default values",

--- a/test/tests/traits.json
+++ b/test/tests/traits.json
@@ -87,7 +87,7 @@
         },
 
         {
-            "name" : "Traits Invalid Assignment",
+            "name" : "Traits Invalid Assignment Ptr of Trait",
             "definitions": `
 
                 trait List {
@@ -118,7 +118,7 @@
         },
 
         {
-            "name" : "Traits Invalid Assignment",
+            "name" : "Traits Invalid Assignment Ptr of trait from non ptr",
             "definitions": `
 
                 trait List {
@@ -149,7 +149,7 @@
         },
 
         {
-            "name" : "Traits Invalid Assignment",
+            "name" : "Traits Invalid Assignment from non ptr",
             "definitions": `
 
                 trait List {
@@ -221,6 +221,7 @@
             `,
         },
 
+        /* We've implemented traits on non-aggregates now
         {
             "name" : "Traits Invalid Type",
             "definitions": `
@@ -245,7 +246,7 @@
                 var list: List = &this;
             `,
             "error": "'*i32' can't be assigned to 'List'; only aggregate types can implement traits"
-        },
+        },*/
 
         {
             "name" : "Traits Partial Implementation",
@@ -945,6 +946,288 @@
                 var function: Function<bool, i32> = &impl
                 assert(function.fn(false) == 4)
             `,
+        },
+        {
+            "name" : "Traits With Generics",
+            "definitions": `
+
+                trait Function<T> {
+                    fn: func(T) : T
+                }
+
+                struct FunctionImpl {
+                    i: i32
+                }
+
+                func (this: *FunctionImpl) fn(i: i32) : i32 {
+                    return this.i + i
+                }
+            `,
+            "code": `
+                var impl = FunctionImpl {
+                    .i = 4
+                }
+
+                var function: Function<i32> = &impl
+                assert(function.fn(1) == 5)
+            `,
+        },
+        {
+            "name" : "Traits With Generics with Default Methods",
+            "definitions": `
+
+                trait Function<T> {
+                    fn: func(T) : T
+                }
+
+                func (this: Function<T>) test<T>(x: T) : T {
+                    return this.fn<T>(x)
+                }
+
+                struct FunctionImpl {
+                    i: i32
+                }
+
+                func (this: *FunctionImpl) fn(i: i32) : i32 {
+                    return this.i + i
+                }
+            `,
+            "code": `
+                var impl = FunctionImpl {
+                    .i = 4
+                }
+
+                var function: Function<i32> = &impl
+                assert(function.fn(1) == 5)
+                assert(function.test(1) == 5)
+            `,
+        },
+        {
+            "name" : "Traits with Default Methods",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: Adder) subAdd(a: i32) : i32 {
+                    var x = this.add(a)
+                    var result = this.sub(x)
+                    return result
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var x = 10
+                var adder: Adder = &x;
+                assert(adder.add(4) == 14)
+                assert(adder.sub(4) == 6)
+                assert(adder.subAdd(2) == -2)
+            `,
+        },
+        {
+            "name" : "Traits with Default Methods with no Impls",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: Adder) subAdd(a: i32) : i32 {
+                    var x = this.add(a)
+                    var result = this.sub(x)
+                    return result
+                }
+            `,
+            "code": `
+
+            `,
+        },
+        {
+            "name" : "Traits invalid assignment to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder: Adder = &4
+            `,
+            "error": "lvalue required as unary '&' operand"
+        },
+        {
+            "name" : "Traits invalid function argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+
+                func Test(adder: Adder) : i32 {
+                    return adder.add(4)
+                }
+            `,
+            "code": `
+                Test(4)
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid init argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = AdderImpl {
+                    .adder = 4
+                }
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array init argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adders:[4]Adder = [4]Adder{
+                    [0] = 4
+                }
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid aggregate argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = AdderImpl{}
+                adder.adder = 4
+            `,
+            "error": "invalid trait assignment from rvalue of type 'i32' to trait type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array argument to rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = [4]Adder{}
+                adder[0] = 4
+            `,
+            "error": "'i32' is not of type 'Adder'"
+        },
+        {
+            "name" : "Traits invalid array argument to address of rvalue",
+            "definitions": `
+
+                trait Adder {
+                    add: func(i32) : i32
+                    sub: func(i32) : i32
+                }
+
+                struct AdderImpl {
+                    adder: Adder
+                }
+
+                func (this: *i32) add(other: i32) : i32 {
+                    return *this + other
+                }
+                func (this: *i32) sub(other: i32) : i32 {
+                    return *this - other
+                }
+            `,
+            "code": `
+                var adder = [4]Adder{}
+                adder[0] = &4
+            `,
+            "error": "lvalue required as unary '&' operand"
         },
     ]
 }


### PR DESCRIPTION
Allow for method definitions on any type not just aggregate types.

Example:

```
func (this: i32) add(other: i32): i32 {
  return this + other
}

var result = 4_i32.add(4)
assert(result == 8)
```