### PR TITLE
added macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/*.rdbg
 bin/*.exp
 bin/*.lib
 bin/litac_linux
+bin/litac_mac
 bin/test.txt
 .vscode/ipch
 bin/litaC.exp
@@ -40,3 +41,4 @@ bootstrap/output/litac_tests.pdb
 bootstrap/output/**
 /.pkgs
 .build.json
+lib/mac

--- a/README.md
+++ b/README.md
@@ -656,6 +656,14 @@ build_bootstrap.sh
 build.sh
 ```
 
+Mac
+```
+git clone https://github.com/tonysparks/litac-lang.git
+cd litac-lang
+build_bootstrap_mac.sh
+zsh build.sh
+```
+
 The `build_bootstrap.bat` will compile the `bootstrap/litac.c` file creating a `litac.exe` (`litac` on Ubuntu).  The `build.bat` file will use the `bootstrap/litac.exe` to build the compiler from lita source (`src/`) and output a new binary in `bin/litac.exe`.
 
 # Using LitaC Compiler

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-BUILD_CMD="gcc %input% -o %output% -D_CRT_SECURE_NO_WARNINGS -I../include -L../lib -ltcc -lm -lrt -lpthread -ldl"
+LFLAGS=""
+OUT_FILE="litac_"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  LFLAGS="-L../lib/mac -ltcc -L../lib -lm -lpthread -ldl -lcurl"
+  OUT_FILE="${OUT_FILE}mac"
+else
+  LFLAGS="-L../lib -ltcc -lm -lrt -lpthread -ldl"
+  OUT_FILE="${OUT_FILE}linux"
+fi
+
+BUILD_CMD="gcc %input% -o %output% -D_CRT_SECURE_NO_WARNINGS -I../include $LFLAGS"
 #set BUILD_CMD="tcc.exe %%input%% -o %%output%%  -D_CRT_SECURE_NO_WARNINGS -I../include -L../lib -llibtcc"
 
 
@@ -18,7 +28,7 @@ build_litac() {
 
     cd bootstrap
 
-    ./litacc -cFormat -profile -buildCmd "${BUILD_CMD}" "../src/main.lita" -outputDir "../bin/" -output "litac_linux" -maxMemory 1GiB
+    ./litacc -cFormat -profile -buildCmd "${BUILD_CMD}" "../src/main.lita" -outputDir "../bin/" -output "$OUT_FILE" -maxMemory 1GiB
     if [ $? -gt 0 ]; then
         error_compiling()
         return 1
@@ -26,7 +36,7 @@ build_litac() {
 
     echo "Running litaC inception!..."
     cd ../bin
-    ./litac_linux -profile -cFormat -buildCmd "${BUILD_CMD}" "../src/main.lita" -maxMemory 1GiB
+    ./${OUT_FILE} -profile -cFormat -buildCmd "${BUILD_CMD}" "../src/main.lita" -maxMemory 1GiB
     if [ $? -gt 0 ]; then
         error_compiling()
         return 1
@@ -48,6 +58,3 @@ fi
 
 #del ".\bin\litacc.*" /q
 #del ".\bin\litac.*" /q
-
-
-

--- a/build_bootstrap_mac.sh
+++ b/build_bootstrap_mac.sh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+
+set -e
+
+if [ ! -d libtcc-cmake ]; then
+  git clone https://github.com/Alex2804/libtcc-cmake
+fi
+cd libtcc-cmake
+if [ ! -d build ]; then
+  mkdir build
+fi
+cd build
+cmake ..
+make
+cd ../..
+
+if [ ! -d lib/mac ]; then
+  mkdir lib/mac
+fi
+cp libtcc-cmake/build/libtcc.a lib/mac/libtcc.a
+rm -rf libtcc-cmake
+
+cd bootstrap
+gcc -o "litacc" "litac_linux.c" -D_CRT_SECURE_NO_WARNINGS -D_DEFAULT_SOURCE -I../include -L../lib/mac -ltcc -L../lib -I../stdlib/std/http/libcurl/include -lm -lpthread -lcurl -ldl
+echo "Successfully built bootstrap"


### PR DESCRIPTION
I added support to compile the compiler for macOS. It will build libtcc from source for macOS.

related issue: https://github.com/tonysparks/litac-lang/issues/25

Credits to @Its-Kenta as well for figuring this out together.