### PR TITLE
Static_if preprocessor

### DIFF
--- a/src/ast.lita
+++ b/src/ast.lita
@@ -286,6 +286,7 @@ public struct CompStmt {
     evaluatedStmt: *Stmt
     body: Array<*Stmt>
     isScriptLoad: bool
+    isStatic: bool
 }
 
 public struct ContinueStmt {

--- a/src/ast_copy.lita
+++ b/src/ast_copy.lita
@@ -450,6 +450,7 @@ public func CopyStmt(stmt: *Stmt, module: *Module) : *Stmt {
                                    CopyStmts(original.body, module),
                                    CopyStmt(end, module) as (*CompStmt),
                                    original.isScriptLoad,
+                                   original.isStatic,
                                    module.allocator)
             return copy
         }

--- a/src/ast_new.lita
+++ b/src/ast_new.lita
@@ -757,6 +757,7 @@ public func NewCompStmt(startPos: SrcPos,
                         body: Array<*Stmt>,
                         end: *CompStmt,
                         isScriptLoad: bool,
+                        isStatic: bool,
                         allocator: *const Allocator) : *Stmt {
     var stmt = new<CompStmt>(allocator)
     stmt.kind = StmtKind.COMP_STMT
@@ -768,6 +769,7 @@ public func NewCompStmt(startPos: SrcPos,
     stmt.body = body
     stmt.evaluatedStmt = null
     stmt.isScriptLoad = isScriptLoad
+    stmt.isStatic = isStatic
     return stmt as (*Stmt)
 }
 

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -1555,6 +1555,43 @@ func (this: using *CGen) emitTraitFuncCall(expr: *FuncCallExpr) {
     }
 }
 
+func (this: using *CGen) emitStaticCompStmt(s: *CompStmt) {
+    if(!s.isStatic) {
+        return;
+    }
+
+    if(s.type.equals(STATIC_IF)) {
+        this.emitStrn("#if", 3)
+        this.emit(" %.*s\n", s.expr.length, s.expr.buffer)
+    }
+    else if(s.type.equals(ELSEIF)) {
+        this.emitStrn("#elif", 5)
+        this.emit(" %.*s\n", s.expr.length, s.expr.buffer)
+    }
+    else if(s.type.equals(ELSE)) {
+        this.emitStrn("#else\n", 6)
+    }
+    else if(s.type.equals(END)) {
+        this.emitStrn("#endif\n", 7)
+    }
+
+    var stmts = s.body
+    for(var i = 0; i < stmts.size(); i += 1) {
+        var n = stmts.get(i)
+        this.emitStmt(n)
+        if(IsExpr(n)) {
+            this.emitStrn(";\n", 2)
+        }
+        else {
+            this.emitStrn("\n", 1)
+        }
+    }
+
+    if(s.end) {
+        this.emitStaticCompStmt(s.end)
+    }
+}
+
 public func (this: using *CGen) emitStmt(s: *Stmt) {
     if(!s) return;
 
@@ -1630,6 +1667,10 @@ public func (this: using *CGen) emitStmt(s: *Stmt) {
         }
         case StmtKind.COMP_STMT: {
             var stmt = s as (*CompStmt)
+            if(stmt.isStatic) {
+                this.emitStaticCompStmt(stmt)
+                return;
+            }
 
             var result = stmt.evaluatedStmt
             if(result) {

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -1376,6 +1376,28 @@ public func (this: *TypeChecker) resolveStmt(stmt: *Stmt) : bool {
         }
         case StmtKind.COMP_STMT: {
             var compStmt = stmt as (*CompStmt)
+            if(compStmt.isStatic) {
+                var stmts = compStmt.body
+                for(var i = 0; i < stmts.size(); i+=1) {
+                    var s = stmts.get(i)
+                    if(!this.resolveStmt(s)) {
+                        return false
+                    }
+                }
+                //
+                // HACK: In order to properly type check
+                // we create a temporary scope, but we only
+                // put the if body in the actual working scope
+                //
+                this.pushScope(&Scope{})
+                defer this.popScope()
+
+                if(compStmt.end && !this.resolveStmt(compStmt.end)) {
+                    return false
+                }
+                return true
+            }
+
             var stmt = this.lita.preprocessor.evaluateForFunction(this, compStmt)
             if(!stmt) {
                 return false;

--- a/src/intern.lita
+++ b/src/intern.lita
@@ -53,6 +53,7 @@ public const PROFILE_TAG = InternedString{};
 public const PROFILE_ENTRIES = InternedString{};
 // compile time statements
 public const IF = InternedString{};
+public const STATIC_IF = InternedString{};
 public const ELSE = InternedString{};
 public const ELSEIF = InternedString{};
 public const PRECHECK = InternedString{};
@@ -150,6 +151,7 @@ public func (this: *Strings) init(allocator: *const Allocator) {
     this.internConstant("profileEntries", 15, &PROFILE_ENTRIES)
 
     this.internConstant("if", 2, &IF)
+    this.internConstant("static_if", 9, &STATIC_IF)
     this.internConstant("else", 4, &ELSE)
     this.internConstant("elseif", 6, &ELSEIF)
     this.internConstant("precheck", 8, &PRECHECK)

--- a/src/parser.lita
+++ b/src/parser.lita
@@ -71,6 +71,8 @@ public struct Parser {
     tryLevel: u32
     tryErrorCounter: u64
     panicMode: bool
+
+    preprocessorLevel: i32
 }
 
 public func ParserInit(filename: *const char,
@@ -96,6 +98,7 @@ public func ParserInit(filename: *const char,
         .aggregateLevel = 0,
         .tryLevel = 0,
         .tryErrorCounter = 0,
+        .preprocessorLevel = 0,
         .panicMode = false,
     }
 
@@ -1504,8 +1507,11 @@ err:
     return p.poisonStatement(pos)
 }
 
-func (p: *Parser) compStatement() : *Stmt {
+func (p: *Parser) compStatement(isStaticIf: bool = false) : *Stmt {
     var pos = p.pos()
+
+    p.preprocessorLevel += 1
+    defer p.preprocessorLevel -= 1
 
     var type: InternedString = EMPTY_STR
     var scriptExpr = StringView{};
@@ -1525,13 +1531,25 @@ func (p: *Parser) compStatement() : *Stmt {
         type = NewTokenNameIntern(*identifier, p.lita.strings)
     }
 
-    if(type.equals(IF) || type.equals(ELSEIF)) {
+    if(type.equals(STATIC_IF)) {
+        isStaticIf = true
+    }
+
+    var isIf = type.equals(IF) || type.equals(STATIC_IF);
+
+    if(p.preprocessorLevel > 1) {
+        if(isIf) {
+            p.result.addError(pos, "'#static_if' and '#if' are only allowed as the first statement in the preprocessor chain")
+            goto err;
+        }
+    }
+
+    if(type.equals(IF) || type.equals(ELSEIF) || type.equals(STATIC_IF)) {
         // read the expression
-        var pos = p.pos()
         var currentLine = pos.lineNumber
         var script = StringBufferInit(128, p.allocator)
 
-        var stream = pos.start
+        var stream = pos.end
         while(*stream) {
             var c = *stream
             if(c == '\n') {
@@ -1570,8 +1588,15 @@ func (p: *Parser) compStatement() : *Stmt {
             p.advance()
         }
 
+        script.trim()
         scriptExpr.buffer = script.cStr()
         scriptExpr.length = script.length
+
+        if(script.length == 0 && isIf) {
+            p.result.addError(pos,
+                "'#static_if' and '#if' must include a conditional expression")
+            goto err;
+        }
 
         var body = ArrayInit<*Stmt>(32, p.allocator)
         while(!p.atEnd()) {
@@ -1589,11 +1614,20 @@ func (p: *Parser) compStatement() : *Stmt {
             goto err;
         }
 
-        var end = p.compStatement()
+        var end = p.compStatement(isStaticIf)
         if(end && end.kind != StmtKind.COMP_STMT) {
             goto err;
         }
-        return NewCompStmt(pos, p.pos(), type, scriptExpr, body, end as (*CompStmt), false, p.allocator)
+        return NewCompStmt(
+            pos,
+            p.pos(),
+            type,
+            scriptExpr,
+            body,
+            end as (*CompStmt),
+            false,
+            isStaticIf,
+            p.allocator)
 
     }
     else if(type.equals(PRECHECK)  ||
@@ -1643,7 +1677,16 @@ func (p: *Parser) compStatement() : *Stmt {
             goto err;
         }
         var body = Array<*Stmt>{}
-        return NewCompStmt(pos, p.pos(), type, scriptExpr, body, end as (*CompStmt), isScriptLoad, p.allocator)
+        return NewCompStmt(
+            pos,
+            p.pos(),
+            type,
+            scriptExpr,
+            body,
+            end as (*CompStmt),
+            isScriptLoad,
+            false,
+            p.allocator)
     }
     else if(type.equals(ELSE)) {
         var body = ArrayInit<*Stmt>(32, p.allocator)
@@ -1662,11 +1705,20 @@ func (p: *Parser) compStatement() : *Stmt {
             goto err;
         }
 
-        var end = p.compStatement()
+        var end = p.compStatement(isStaticIf)
         if(end && end.kind != StmtKind.COMP_STMT) {
             goto err;
         }
-        return NewCompStmt(pos, p.pos(), type, scriptExpr, body, end as (*CompStmt), false, p.allocator)
+        return NewCompStmt(
+            pos,
+            p.pos(),
+            type,
+            scriptExpr,
+            body,
+            end as (*CompStmt),
+            false,
+            isStaticIf,
+            p.allocator)
     }
     else if(type.equals(ELSE_ERROR)) {
         var message = p.consume(TokenType.STRING, ErrorCode.MISSING_ERROR_MESSAGE)
@@ -1678,15 +1730,15 @@ func (p: *Parser) compStatement() : *Stmt {
             goto err;
         }
 
-        var end = p.compStatement()
+        var end = p.compStatement(isStaticIf)
         if(end && end.kind != StmtKind.COMP_STMT) {
             goto err;
         }
 
-        return NewCompStmt(pos, p.pos(), type, message.str, Array<*Stmt>{}, null, false, p.allocator)
+        return NewCompStmt(pos, p.pos(), type, message.str, Array<*Stmt>{}, null, false, isStaticIf, p.allocator)
     }
     else if(type.equals(END)) {
-        return NewCompStmt(pos, p.pos(), type, StringView{}, Array<*Stmt>{}, null, false, p.allocator)
+        return NewCompStmt(pos, p.pos(), type, StringView{}, Array<*Stmt>{}, null, false, isStaticIf, p.allocator)
     }
     else {
         p.errorAtToken(p.peek(), ErrorCode.INVALID_COMP_STMT)

--- a/src/preprocessor.lita
+++ b/src/preprocessor.lita
@@ -229,11 +229,23 @@ public func (this: *Preprocessor) evaluateForModule(
 }
 
 @profile
-public func (this: *Preprocessor) evaluateForFunction(checker: *TypeChecker, comp: *CompStmt) : *Stmt {
+public func (this: *Preprocessor) evaluateForFunction(
+        checker: *TypeChecker,
+        comp: *CompStmt,
+        isFirst: bool = true) : *Stmt {
+
     assert(comp != null)
 
     if(comp.evaluatedStmt) {
         return comp.evaluatedStmt
+    }
+
+    if(!isFirst) {
+        if(comp.type.equals(IF) || comp.type.equals(STATIC_IF)) {
+            this.lita.result.addError(
+                comp.startPos, "'#static_if' and '#if' are only allowed as the first statement in the preprocessor chain.")
+            return null
+        }
     }
 
     this.callContext.checker = checker
@@ -247,14 +259,19 @@ public func (this: *Preprocessor) evaluateForFunction(checker: *TypeChecker, com
             comp.evaluatedStmt = NewBlockStmt(comp.startPos, comp.endPos, comp.body, this.lita.allocator)
         }
         else if(comp.end) {
-            comp.evaluatedStmt = this.evaluateForFunction(checker, comp.end)
+            comp.evaluatedStmt = this.evaluateForFunction(checker, comp.end, false)
         }
     }
+    else if(comp.type.equals(STATIC_IF) ||
+            comp.type.equals(ELSE)) {
 
+        this.lita.result.addError(
+            comp.startPos, "'#static_if' is not allowed in '#if' chains")
+        return null
+    }
     else if(comp.type.equals(ELSE_ERROR)) {
         this.lita.result.addError(
             comp.startPos, "%.*s", comp.expr.length, comp.expr.buffer)
-
     }
 
     if(!comp.evaluatedStmt) {

--- a/stdlib/std/string_buffer.lita
+++ b/stdlib/std/string_buffer.lita
@@ -3,6 +3,7 @@ import "std/io";
 import "std/assert";
 import "std/string_view";
 import "std/libc";
+import "std/ascii";
 
 const MAX_BUFFER_SIZE = 32;
 
@@ -275,6 +276,42 @@ public func (b: *StringBuffer) insert(index: i32, format: *const char, ...) : i3
     return len
 }
 
+public func (b: *StringBuffer) trim() {
+    var start = 0
+    var end = 0
+
+    // Delete the left side
+    for(var i = 0; i < b.length; i+=1) {
+        var c = b.buffer[i]
+        if(c.isWhitespace()) {
+            end += 1
+        }
+        else {
+            break
+        }
+    }
+
+    if(end > start) {
+        b.delete(start, end)
+    }
+
+    // Delete the right side
+    start = b.length - 1;
+    end = b.length - 1;
+    for(var i = b.length - 1; i >= 0; i-=1) {
+        var c = b.buffer[i]
+        if(c.isWhitespace()) {
+            start -= 1
+        }
+        else {
+            break
+        }
+    }
+
+    if(end > start) {
+        b.delete(start, end)
+    }
+}
 
 public func (b: *StringBuffer) copyTo(buf: *char, len: i32, addZero: bool = true) : i32 {
     var view = b.asStringView()

--- a/test/test_suite.lita
+++ b/test/test_suite.lita
@@ -76,7 +76,7 @@ func main(len: i32, args: **char) : i32 {
         // "../test/tests/misc.json", json syntax error
         //"../test/tests/from_json.json",
         //"../test/tests/to_json.json",
-
+        "../test/tests/static_if.json",
         "../test/tests/single.json",
         "../test/tests/bugs.json",
         "../test/tests/bucket_allocator.json",

--- a/test/tests/static_if.json
+++ b/test/tests/static_if.json
@@ -1,0 +1,266 @@
+{
+    "description": "Aggregates",
+    "disabled": false,
+    "debug": true,
+    "disableLines": true,
+    "includeTypeInfos": false,
+    "program": `
+        @include("assert.h");
+        @foreign func assert(e:bool):void;
+
+        %definitions%
+
+        func main(len:i32, args:**char):i32 {
+            %code%
+        }
+    `,
+    "tests": [
+        {
+            "name": "Static If no body",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if IS_TRUE
+                #end
+            `,
+        },
+        {
+            "name": "Static If ElseIf no body",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if IS_FALSE
+                #elseif IS_FALSE
+                #end
+            `,
+        },
+        {
+            "name": "Static If ElseIf Else no body",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if IS_FALSE
+                #elseif IS_FALSE
+                #else
+                #end
+            `,
+        },
+        {
+            "name": "Static Ifdef true",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #static_if IS_TRUE
+                    var x = 0
+                #end
+
+                assert(x == 0)
+            `,
+        },
+        {
+            "name": "Static Ifdef false",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if defined(IS_TRUE)
+                    var x = 0
+                #end
+            `,
+        },
+        {
+            "name": "Static Ifdef Else",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if defined(IS_FALSE)
+                    var x = 0
+                #else
+                    var x = 1
+                #end
+
+                assert(x == 1)
+            `,
+        },
+        // ifndef
+        {
+            "name": "Static Ifndef true",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #static_if defined(IS_TRUE)
+                    var x = 0
+                #end
+            `,
+        },
+        {
+            "name": "Static Ifndef false",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if !defined(IS_TRUE)
+                    var x = 0
+                #end
+                assert(x == 0)
+            `,
+        },
+        {
+            "name": "Static Ifndef Else",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if !defined(IS_FALSE)
+                    var x = 0
+                #else
+                    var x = 1
+                #end
+
+                assert(x == 0)
+            `,
+        },
+
+        // with elseif
+        {
+            "name": "Static If true elseif",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #static_if IS_TRUE
+                    var x = 0
+                #elseif defined(IS_FALSE)
+                    var x = 1
+                #end
+            `,
+        },
+        {
+            "name": "Static If false elseif",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if !defined(IS_TRUE)
+                    var x = 0
+                #elseif IS_FALSE
+                    var x = 1
+                #end
+                assert(x == 0)
+            `,
+        },
+        {
+            "name": "Static If Else elseif",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if defined(IS_FALSE)
+                    var x = 0
+                #elseif defined(IS_FALSE)
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+
+                assert(x == 2)
+            `,
+        },
+        {
+            "name": "Static If Else elseif true",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #static_if defined(IS_FALSE)
+                    var x = 0
+                #elseif IS_TRUE
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+
+                assert(x == 1)
+            `,
+        },
+
+        // Errors
+
+        {
+            "name": "Static If with If false",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #if false
+                    var x = -1
+                #static_if defined(IS_FALSE)
+                    var x = 0
+                #elseif IS_TRUE
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+
+                assert(x == 1)
+            `,
+            "error": "'#static_if' and '#if' are only allowed as the first statement in the preprocessor chain"
+        },
+        {
+            "name": "Static If with If true",
+            "definitions": `
+                @raw("#define IS_TRUE 1");
+            `,
+            "code": `
+                #if true
+                    var x = -1
+                #static_if defined(IS_FALSE)
+                    var x = 0
+                #elseif IS_TRUE
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+            `,
+            "error": "'#static_if' and '#if' are only allowed as the first statement in the preprocessor chain"
+        },
+        {
+            "name": "Static If No Cond",
+            "definitions": `
+
+            `,
+            "code": `
+                #static_if
+                    var x = 0
+                #elseif IS_TRUE
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+            `,
+            "error": "'#static_if' and '#if' must include a conditional expression"
+        },
+        {
+            "name": "If No Cond",
+            "definitions": `
+
+            `,
+            "code": `
+                #if
+                    var x = 0
+                #elseif IS_TRUE
+                    var x = 1
+                #else
+                    var x = 2
+                #end
+            `,
+            "error": "'#static_if' and '#if' must include a conditional expression"
+        },
+    ]
+}


### PR DESCRIPTION
Implement the `#static_if` preprocessor directive to enable C preprocessor directives in the generated output.

This feature enables more advanced bootstrapping (supporting conditional build targets).