### PR TITLE
Fix fully qualified type name

### DIFF
--- a/src/checker.lita
+++ b/src/checker.lita
@@ -947,14 +947,22 @@ public func (this: *TypeChecker) getTypeByName(typeName: InternedString, isFunc:
     // modules without having to import them all into
     // the current module
     if(!type && this.bypassing) {
+        //printf("Finding type in bypass: %.*s\n", typeName.length, typeName.buffer)
         var name = typeName.view
-        var index = name.indexOf("::")
+        var index = name.lastIndexOfAt("::")
         if(index < 0) {
             return null
         }
-        var mod = name.substring(0, index)
+
+        var modulePath = ToModulePath(name.substring(0, index))
         var filename = [MAX_PATH]char{0}
-        if(!FindModulePath(this.lita, mod, filename)) {
+
+        if(!FindModulePath(this.lita, modulePath, filename)) {
+            for(var it = this.lita.modules.iter(); it.hasNext();) {
+                var entry = it.next()
+                printf("Module: %.*s\n",entry.value.id.packageName.length, entry.value.id.packageName.buffer)
+            }
+            printf("Couldn't find module in bypass: %.*s\n", modulePath.length, modulePath.buffer)
             return null
         }
 

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -947,7 +947,6 @@ public func (this: *TypeChecker) getTypeByName(typeName: InternedString, isFunc:
     // modules without having to import them all into
     // the current module
     if(!type && this.bypassing) {
-        //printf("Finding type in bypass: %.*s\n", typeName.length, typeName.buffer)
         var name = typeName.view
         var index = name.lastIndexOfAt("::")
         if(index < 0) {
@@ -958,11 +957,6 @@ public func (this: *TypeChecker) getTypeByName(typeName: InternedString, isFunc:
         var filename = [MAX_PATH]char{0}
 
         if(!FindModulePath(this.lita, modulePath, filename)) {
-            for(var it = this.lita.modules.iter(); it.hasNext();) {
-                var entry = it.next()
-                printf("Module: %.*s\n",entry.value.id.packageName.length, entry.value.id.packageName.buffer)
-            }
-            printf("Couldn't find module in bypass: %.*s\n", modulePath.length, modulePath.buffer)
             return null
         }
 

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -364,8 +364,6 @@ func (this: *TypeChecker) inferredType(name: Identifier, paramType: *TypeInfo, e
     assert(paramType != null)
     assert(expectedType != null)
 
-//printf("Here for %.*s!!\n", paramType.name.length, paramType.name.buffer)
-
     if(name.str.equals(paramType.name)) {
         return expectedType
     }

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -364,6 +364,8 @@ func (this: *TypeChecker) inferredType(name: Identifier, paramType: *TypeInfo, e
     assert(paramType != null)
     assert(expectedType != null)
 
+//printf("Here for %.*s!!\n", paramType.name.length, paramType.name.buffer)
+
     if(name.str.equals(paramType.name)) {
         return expectedType
     }

--- a/src/error_codes.lita
+++ b/src/error_codes.lita
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_COMP_STMT,
     INVALID_DEFAULT_ASSIGNMENT,
     INVALID_TRAIT_MEMBER,
+    INVALID_TYPE_IDENTIFIER,
 
     MISSING_COMMA,
     MISSING_SEMICOLON,
@@ -74,6 +75,7 @@ public const errorCodeText = []*const char {
     [ErrorCode.INVALID_COMP_STMT] = "Invalid compile time statement",
     [ErrorCode.INVALID_DEFAULT_ASSIGNMENT] = "Invalid default assignment statement, only allowed for 'struct'",
     [ErrorCode.INVALID_TRAIT_MEMBER] = "Invalid trait member, only function pointers are allowed",
+    [ErrorCode.INVALID_TYPE_IDENTIFIER] = "Invalid fully qualified type identifier.  Qualified names must follow this format 'std.example::MyType'",
 
     [ErrorCode.MISSING_COMMA] = "Missing ,",
     [ErrorCode.MISSING_SEMICOLON] = "Missing ;",

--- a/src/lita.lita
+++ b/src/lita.lita
@@ -325,7 +325,8 @@ public func (this: *Lita) parse() : *Module {
         return null;
     }
 
-    var root = NewModule(this, this.options.inputFile)
+    var packageName = GetPackageName(this.options.srcPath, this.options.inputFile)
+    var root = NewModule(this, packageName, this.options.inputFile)
     this.addModule(root)
 
     if(!ParseModule(this, root, SrcPos{})) {
@@ -741,7 +742,7 @@ func ParseModule(lita: *Lita, module: *Module, pos: SrcPos) : bool {
             continue;
         }
 
-        importModule = NewModule(lita, filename)
+        importModule = NewModule(lita, importStmt.name.str.view, filename)
         importStmt.moduleId = &importModule.id
         lita.addModule(importModule)
 
@@ -749,4 +750,51 @@ func ParseModule(lita: *Lita, module: *Module, pos: SrcPos) : bool {
     }
 
     return true
+}
+
+
+func GetPackageName(srcPath: *const char, inputFile: *const char) : StringView {
+
+    if(!inputFile) {
+        return StringView{}
+    }
+
+    if(srcPath) {
+        var inputFileView = StringViewInit(inputFile)
+        var index = inputFileView.indexOf(srcPath)
+        if(index > -1) {
+            inputFile = &inputFile[index + strlen(srcPath) + 1]
+        }
+    }
+
+    var endCount = 0
+    var startCount = 0
+
+    var inputLen = strlen(inputFile)
+
+    while(*inputFile) {
+
+        var c = *inputFile;
+
+        if(c != '.' && c != '/' && c != '\\') {
+            break
+        }
+
+        inputFile  += 1
+        startCount += 1
+    }
+
+    for(var i = inputLen; i >= 0; i-=1) {
+        var c = inputFile[i]
+        if(c == '.') {
+            break
+        }
+
+        endCount += 1
+    }
+
+    return StringView {
+        .length = inputLen - (endCount+startCount),
+        .buffer = inputFile,
+    }
 }

--- a/src/module.lita
+++ b/src/module.lita
@@ -27,13 +27,13 @@ public enum ModuleFlags {
 }
 
 public struct ModuleId {
-    filename: [MAX_PATH]char   // full path the file of this module
+    filename: [MAX_PATH]char      // full path the file of this module
 
     filenameKey: [MAX_PATH]char   // full path the file of this module, normalized to a 'key', not
                                   // to be used for file retrieval operations
 
-    packageName: StringView    // relative path from the main module's directory
-    name: InternedString       // the name of the module
+    packageName: InternedString   // relative path from the main module's directory
+    name: InternedString          // the name of the module
 }
 
 public struct ModuleImport {
@@ -89,7 +89,7 @@ public func BuiltinsInit(lita: *Lita) : *Module {
     var filename: [MAX_PATH]char;
     var pathStr = StringInit(filename, MAX_PATH, 0);
     pathStr.format("%s/stdlib/std/builtins.lita", lita.options.litaPath)
-    builtins.id.fromFile(lita, pathStr.cStr())
+    builtins.id.fromFile(lita, StringViewInit("std/builtins"), pathStr.cStr())
 
     AddBuiltin(lita, &BOOL_TYPE)
     AddBuiltin(lita, &CHAR_TYPE)
@@ -135,11 +135,12 @@ public func GetBuiltinSymbol(typeid: Typeid) : *Symbol {
 }
 
 public func NewModule(lita: *Lita,
+                      packageName: StringView,
                       filename: *const char) : *Module {
 
     var mod = new<Module>(lita.allocator)
     mod.init(lita)
-    mod.id.fromFile(lita, filename)
+    mod.id.fromFile(lita, packageName, filename)
     return mod
 }
 
@@ -425,15 +426,64 @@ public func (this: *Module) print(header: *const char) {
     printf("}\n")
 }
 
-public func (moduleId: *ModuleId) fromFile(lita: *Lita, filename: *const char) {
+public func (moduleId: *ModuleId) fromFile(lita: *Lita, packageName: StringView, filename: *const char) {
     GetAbsolutePath(CurrentWorkingPath(), filename, moduleId.filename)
     GetFilenameKey(filename, moduleId.filenameKey)
 
-    moduleId.packageName = StringViewInit(moduleId.filename, 0)
+    var pkg = ToModuleName(packageName)
+    moduleId.packageName = lita.strings.internCopy(pkg.buffer, pkg.length)
 
     var pathStr = StringViewInit(moduleId.filename);
     var name = GetModuleName(pathStr)
     moduleId.name = lita.strings.internCopy(name.buffer, name.length)
+}
+
+public func ToModulePath(moduleName: StringView) : StringView {
+    @static var modulePath = [MAX_SYMBOL_NAME]char{0}
+    var len = 0
+    for(var i = 0; i < moduleName.length; i+=1) {
+        var c = moduleName.buffer[i]
+        if(c == ':') {
+            c = '/'
+
+            // skip the next character
+            i+=1
+        }
+
+        modulePath[len] = c
+        len += 1
+    }
+
+    return StringView {
+        .length = len,
+        .buffer = modulePath,
+    }
+}
+
+public func ToModuleName(modulePath: StringView) : StringView {
+    @static var moduleName = [MAX_SYMBOL_NAME]char{0}
+
+    var len = 0
+    for(var i = 0; i < modulePath.length; i+=1) {
+        var c = modulePath.buffer[i]
+        if(c == '/' || c =='\\') {
+            moduleName[len + 0] = ':'
+            moduleName[len + 1] = ':'
+            len += 2
+        }
+        else if(c == '.') {
+            continue
+        }
+        else {
+            moduleName[len] = c
+            len += 1
+        }
+    }
+
+    return StringView {
+        .length = len,
+        .buffer = moduleName,
+    }
 }
 
 public func GetModuleName(pathStr: StringView) : StringView {
@@ -462,4 +512,3 @@ public func GetModuleName(pathStr: StringView) : StringView {
         .length = endIndex - startIndex
     }
 }
-

--- a/src/parser.lita
+++ b/src/parser.lita
@@ -357,7 +357,7 @@ func (p: *Parser) notes(notes: *Array<*NoteStmt>) : bool {
     while(p.match(TokenType.AT)) {
         var pos = p.prevPos()
 
-        var type = p.identifierType(true)
+        var type = p.qualifiedIdentifierType(true)
         if(!type) {
             goto err;
         }
@@ -1321,7 +1321,7 @@ func (p: *Parser) primary() : *Expr {
     }
 
     if(p.check(TokenType.IDENTIFIER)) {
-        var name = p.identifierType(true)
+        var name = p.qualifiedIdentifierType(true)
         if(!name) {
             goto err;
         }
@@ -2149,7 +2149,7 @@ func (p: *Parser) type(disambiguate: bool = false) : *TypeSpec {
             return spec as (*TypeSpec)
         }
         case TokenType.IDENTIFIER: {
-            return p.identifierType(disambiguate) as (*TypeSpec)
+            return p.qualifiedIdentifierType(disambiguate) as (*TypeSpec)
         }
         case TokenType.LEFT_BRACKET: {
             var spec = p.arrayType()
@@ -2185,7 +2185,32 @@ func (p: *Parser) identifierType(disambiguate: bool) : *TypeSpec {
     var sb = StringInit(buffer, MAX_SYMBOL_NAME, 0)
     sb.appendStrn(name.str.buffer, name.str.length)
 
-    if(p.match(TokenType.COLON_COLON)) {
+    var spec = NewTypeSpec(TypeSpecKind.NAME, pos, p.typeAllocator)
+    spec.name = p.lita.strings.internCopy(sb.cStr(), sb.length)
+
+    if(p.check(TokenType.LESS_THAN)) {
+        spec.genericArgs = p.tryGenericArguments(disambiguate)
+    }
+
+    return spec;
+
+err:
+    return null
+}
+
+func (p: *Parser) qualifiedIdentifierType(disambiguate: bool) : *TypeSpec {
+    var pos = p.pos()
+
+    var name = p.identifier()
+    if(name.type != TokenType.IDENTIFIER) {
+        goto err;
+    }
+
+    var buffer:[MAX_SYMBOL_NAME]char;
+    var sb = StringInit(buffer, MAX_SYMBOL_NAME, 0)
+    sb.appendStrn(name.str.buffer, name.str.length)
+
+    while(p.match(TokenType.COLON_COLON)) {
         var identifier = p.identifier()
         if(identifier.type != TokenType.IDENTIFIER) {
             goto err;

--- a/src/traits.lita
+++ b/src/traits.lita
@@ -130,7 +130,7 @@ public func CreateTraitWrappers(checker: *TypeChecker) : Array<*Decl> {
             impls)
     }
 
-    //printf("Traits Source: \n%s\n", sb.cStr())
+    // printf("Traits Source: \n%s\n", sb.cStr())
     var parser = ParserInit("generated", sb.cStr(), sb.length, checker.current, checker.lita)
     var stmts = parser.parseModule()
     return stmts.declarations
@@ -145,23 +145,23 @@ func GenerateVTable(
     sb.append(" {\n")
 
     for(var j = 0; j < traitDecl.fields.size(); j += 1) {
-            var field = traitDecl.fields.get(j)
-            assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
-            assert(field.typeInfo != null && field.typeInfo.kind == TypeKind.FUNC_PTR)
+        var field = traitDecl.fields.get(j)
+        assert(field.kind == StmtKind.TRAIT_FIELD_DECL)
+        assert(field.typeInfo != null && field.typeInfo.kind == TypeKind.FUNC_PTR)
 
-            var fn = field.typeInfo
-            var traitField = field.traitField
-            sb.append("    %.*s: func", traitField.name.str.length, traitField.name.str.buffer)
-            PrintGenerics(fn.genericParams, sb)
-            sb.append("(*void")
-            for(var p = 0; p < fn.paramDecls.size(); p += 1) {
-                var param = fn.paramDecls.get(p)
-                sb.append(", ")
-                param.toString(sb)
-            }
-            sb.append(") : ")
-            fn.returnType.toString(sb)
-            sb.append(";\n")
+        var fn = field.typeInfo
+        var traitField = field.traitField
+        sb.append("    %.*s: func", traitField.name.str.length, traitField.name.str.buffer)
+        PrintGenerics(fn.genericParams, sb)
+        sb.append("(*void")
+        for(var p = 0; p < fn.paramDecls.size(); p += 1) {
+            var param = fn.paramDecls.get(p)
+            sb.append(", ")
+            param.toString(sb, true)
+        }
+        sb.append(") : ")
+        fn.returnType.toString(sb, true)
+        sb.append(";\n")
     }
     sb.append("}\n")
 }
@@ -207,7 +207,7 @@ func GenerateWrapperFunctions(
             for(var p = 0; p < fn.paramDecls.size(); p += 1) {
                 var param = fn.paramDecls.get(p)
                 sb.append(", _%d: ", p)
-                param.toString(sb)
+                param.toString(sb, true)
             }
 
             if(fn.hasVarargs) {
@@ -216,7 +216,7 @@ func GenerateWrapperFunctions(
             }
 
             sb.append(") : ")
-            fn.returnType.toString(sb)
+            fn.returnType.toString(sb, true)
             sb.append(" {\n")
             {
                 if(implSym.declared.isBuiltin()) {
@@ -318,7 +318,7 @@ func PrintGenericArgs(genericArgs: *Array<*TypeInfo>, sb: *StringBuffer) {
 
         var type = genericArgs.get(x)
         assert(type)
-        type.toString(sb)
+        type.toString(sb, true)
     }
     if(genericArgs.size() > 0) {
         sb.append(">")

--- a/src/types.lita
+++ b/src/types.lita
@@ -503,7 +503,7 @@ public func (this: *TypeInfo) toStringDebug() : *const char {
     return sb.cStr()
 }
 
-public func (this: *TypeInfo) toString(sb: *StringBuffer) {
+public func (this: *TypeInfo) toString(sb: *StringBuffer, fullyQualify: bool = false) {
     if(!this) return;
 
     switch(this.kind) {
@@ -522,13 +522,21 @@ public func (this: *TypeInfo) toString(sb: *StringBuffer) {
         case TypeKind.USIZE:
         case TypeKind.NULL:
         case TypeKind.VOID:
+        case TypeKind.GENERIC_PARAM: {
+            sb.appendStrn(this.name.buffer, this.name.length)
+            break;
+        }
         case TypeKind.STRUCT:
         case TypeKind.UNION:
         case TypeKind.TRAIT:
-        case TypeKind.ENUM:
-        case TypeKind.GENERIC_PARAM:
+        case TypeKind.ENUM: {
+            if(fullyQualify && this.sym) {
+                var name = this.sym.declared.id.packageName
+                sb.append("%.*s::", name.length, name.buffer)
+            }
             sb.appendStrn(this.name.buffer, this.name.length)
             break;
+        }
         case TypeKind.STR: {
             sb.appendStr("*const char")
             break;
@@ -541,19 +549,19 @@ public func (this: *TypeInfo) toString(sb: *StringBuffer) {
             else {
                 sb.appendStrn("[]", 2)
             }
-            arrayInfo.arrayOf.toString(sb)
+            arrayInfo.arrayOf.toString(sb, fullyQualify)
             break;
         }
         case TypeKind.PTR: {
             var ptrInfo = this
             sb.appendStrn("*", 1)
-            ptrInfo.ptrOf.toString(sb)
+            ptrInfo.ptrOf.toString(sb, fullyQualify)
             break;
         }
         case TypeKind.CONST: {
             var constInfo = this
             sb.appendStrn("const ", 6)
-            constInfo.constOf.toString(sb)
+            constInfo.constOf.toString(sb, fullyQualify)
             break;
         }
         case TypeKind.FUNC_PTR: {
@@ -572,10 +580,10 @@ public func (this: *TypeInfo) toString(sb: *StringBuffer) {
             for(var i = 0; i < funcPtrInfo.paramDecls.size(); i += 1) {
                 if(i > 0) sb.appendStrn(",", 1)
                 var paramType = funcPtrInfo.paramDecls.get(i)
-                paramType.toString(sb)
+                paramType.toString(sb, fullyQualify)
             }
             sb.appendStr(") : ")
-            funcPtrInfo.returnType.toString(sb)
+            funcPtrInfo.returnType.toString(sb, fullyQualify)
             break;
         }
         case TypeKind.FUNC: {
@@ -594,10 +602,10 @@ public func (this: *TypeInfo) toString(sb: *StringBuffer) {
             for(var i = 0; i < funcInfo.funcDecl.params.size(); i += 1) {
                 if(i > 0) sb.appendStrn(",", 1)
                 var paramType = funcInfo.funcDecl.params.get(i)
-                paramType.typeInfo.toString(sb)
+                paramType.typeInfo.toString(sb, fullyQualify)
             }
             sb.appendStr(") : ")
-            funcInfo.returnType.toString(sb)
+            funcInfo.returnType.toString(sb, fullyQualify)
             break;
         }
         case TypeKind.POISON: {

--- a/stdlib/std/json/json.lita
+++ b/stdlib/std/json/json.lita
@@ -26,7 +26,7 @@ public @note json {
 #postcheck
     "post_serialization.ape"
 #end
-
+/*
 public trait Maker {
     make: func(*JsonContext) : *void;
 }
@@ -53,7 +53,7 @@ public func (this: *JsonContext) init(
     this.allocator = allocator
     this.maker = maker
     //this.makeFns.init(null as (*Maker), 16, PtrHashFn, PtrEqualFn<typeid>, allocator, 0_u64)
-}
+}*/
 
 /*
 public func (this: *JsonContext) getMakeFn(type: typeid) : *Maker {

--- a/stdlib/std/json/json.lita
+++ b/stdlib/std/json/json.lita
@@ -26,7 +26,7 @@ public @note json {
 #postcheck
     "post_serialization.ape"
 #end
-/*
+
 public trait Maker {
     make: func(*JsonContext) : *void;
 }
@@ -37,7 +37,7 @@ public typedef func(typeid, *JsonContext) : *void as MakeFn;
 public struct JsonContext {
     allocator: *const mem::Allocator
     maker: MakeFn
-    //makeFns: Map<typeid, *Maker>
+   // makeFns: Map<typeid, *Maker>
 }
 public func JsonContextInit(
     maker: MakeFn,
@@ -52,8 +52,8 @@ public func (this: *JsonContext) init(
     allocator: *const mem::Allocator = mem::defaultAllocator) {
     this.allocator = allocator
     this.maker = maker
-   // this.makeFns.init(null as (*Maker), 16, PtrHashFn, PtrEqualFn, allocator, 0_u64)
-}*/
+    //this.makeFns.init(null as (*Maker), 16, PtrHashFn, PtrEqualFn<typeid>, allocator, 0_u64)
+}
 
 /*
 public func (this: *JsonContext) getMakeFn(type: typeid) : *Maker {

--- a/test/test_suite.lita
+++ b/test/test_suite.lita
@@ -76,6 +76,7 @@ func main(len: i32, args: **char) : i32 {
         // "../test/tests/misc.json", json syntax error
         //"../test/tests/from_json.json",
         //"../test/tests/to_json.json",
+
         "../test/tests/static_if.json",
         "../test/tests/single.json",
         "../test/tests/bugs.json",
@@ -334,7 +335,6 @@ func RunTest(suite: *TestSuite, test: *Test) : TestResult {
         }
         else {
             options.compileCmd = "clang %input% -o %output% -D_CRT_SECURE_NO_WARNINGS"
-            //options.compileCmd = "tcc %input% -o %output% -D_CRT_SECURE_NO_WARNINGS"
         }
     }
 

--- a/test/tests/traits.json
+++ b/test/tests/traits.json
@@ -1229,5 +1229,57 @@
             `,
             "error": "lvalue required as unary '&' operand"
         },
+        {
+            "name" : "Traits With Complex Type",
+            "definitions": `
+
+
+                public trait List {
+                    size: func() : i32
+                    add:  func(*ComplexType) : void
+                }
+
+                struct ArrayList {
+                    len: i32
+                }
+
+
+                struct ComplexType {
+                    a: i32
+                    list: List
+                }
+
+                func (this: *ArrayList) size() : i32 {
+                    return this.len
+                }
+                func (this: *ArrayList) add(item : *ComplexType) {
+                    this.len += item.a
+                }
+
+                func DoSomething(x: List, item: *ComplexType) : i32 {
+                    x.add(item)
+                    return x.size()
+                }
+            `,
+            "code": `
+                var array = ArrayList{
+                    .len = 0
+                }
+                var complex4 = ComplexType {
+                    .a = 4,
+                    .list = &array
+                }
+
+                var complex2 = ComplexType {
+                    .a = 2,
+                    .list = &array
+                }
+                var result = DoSomething(&array, &complex4)
+                assert(result == 4)
+
+                result = DoSomething(&array, &complex2)
+                assert(result == 6)
+            `,
+        },
     ]
 }


### PR DESCRIPTION
Fixes the qualified type name syntax.  Prior, for a type defined in `std/json` the syntax only allowed for `json::Type` which is incorrect - now it allows for `std::json::Type` which is fully qualified.