### PR TITLE
Enable compiler configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin/*.pdb
 bin/*.rdbg
 bin/*.exp
 bin/*.lib
+bin/*.out
 bin/litac_linux
 bin/litac_mac
 bin/test.txt

--- a/README.md
+++ b/README.md
@@ -636,9 +636,16 @@ If you only want to run a subset of unit tests, you can define a Regular Express
 In order to build litaC compiler you will need:
 * C compiler (tcc, clang and gcc should work -- I haven't tested Visual Studio's compiler)
 
-_NOTE_: Currently, only tested and buildable for Windows x64, Linux (Ubuntu) and MacOS
+_NOTE_: Currently, only tested and buildable for Windows x64, Linux (Ubuntu, Fedora 38) and MacOS
 
 Admittedly, this process isn't as friendly right now as it should be.  At some point I will write more robust build scripts (also LitaC compiler is lacking some features to enable this).  For now, `clang` is hardcoded in the scripts - but should be easy enough to switch to another compiler (tcc or gcc).
+
+### Configure the compiler
+
+The file `src/config.lita` has some parameters to configure the compiler,
+it is documented and should be easy to grasp.
+
+### Build
 
 Windows
 ```

--- a/build.sh
+++ b/build.sh
@@ -44,15 +44,7 @@ build_litac() {
 
     echo Completed.
 }
+LITAC_HOME=${LITAC_HOME:-${PWD}}
 echo "Environment variable: ${LITAC_HOME}"
-if [ -z "${LITAC_HOME}" ]; then
-    echo ""
-    echo "=========================================="
-    echo "ERROR: It appears you do not have the 'LITAC_HOME' system variable defined.  Please make sure this is set to the home directory of litac"
-    echo "=========================================="
-    echo ""
-    exit 2
-else
-    build_litac
-fi
+build_litac
 

--- a/src/config.lita
+++ b/src/config.lita
@@ -1,0 +1,31 @@
+/*
+  definitions for compiler
+
+  these are the default options for some of the parameters
+  
+  those parameters can always be set by the command line
+*/
+
+// the default LITAC_HOME,
+// this is mostly used to look for the library definition files
+// (the `stdlib` directory)
+// if you plan to _install_ to a _system_ directory (e.g. /opt/litac/, or /usr/lib/litac)
+// you can change this to point there.
+//
+// this can be overriden by the `LITAC_HOME` environment variable
+public const LITAC_HOME_DEFAULT : *const char = "";
+
+// the default -buildCmd
+// change to 'gcc' or 'tcc' if you'd prefer
+public const BUILD_CMD_DEFAULT : *const char = "clang %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS";
+
+// default -outputDir
+// this writes the output files to the current directory,
+// you may want to change to `./output` (or similar)
+// if you'd prefer to have a separate directory for builds
+public const OUTPUT_DIR_DEFAULT : *const char = ".";
+
+// default binary name for output (-o,-output)
+// this is the default name for linux binaries
+// for windows you may want to give it a `.exe` extension
+public const OUTPUT_NAME_DEFAULT : *const char = "a.out";

--- a/src/main.lita
+++ b/src/main.lita
@@ -30,6 +30,8 @@ import "build"
 
 import "pkg_mgr"
 
+import "config"
+
 func main(len: i32, args: **char) : i32 {
     var startTime = SystemTimeMSec()
 
@@ -227,7 +229,7 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     }
 
     var lib:*const char = GetEnv("LITAC_HOME")
-    if(!lib) lib = "";
+    if(!lib) lib = LITAC_HOME_DEFAULT;
 
     GetAbsolutePath("", lib, options.litaPath)
 
@@ -294,16 +296,16 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
         options.compileCmd = parser.getOption("buildCmd").value
     }
     else {
-        options.compileCmd = "clang %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS"
+        options.compileCmd = BUILD_CMD_DEFAULT;
     }
 
     var cPrefix = parser.hasOption("cPrefix") ? parser.getOption("cPrefix").value : "litaC_"
     StringCopy(.src = cPrefix, .dest = options.cPrefix, .size = MAX_PREFIX_SIZE)
 
-    var outputFile = parser.hasOption("output") ? parser.getOption("output").value : "a"
+    var outputFile = parser.hasOption("output") ? parser.getOption("output").value : OUTPUT_NAME_DEFAULT
     StringCopy(.src = outputFile, .dest = options.outputFile, .size = MAX_PATH)
 
-    var outputPath = parser.hasOption("outputDir") ? parser.getOption("outputDir").value : "./output"
+    var outputPath = parser.hasOption("outputDir") ? parser.getOption("outputDir").value : OUTPUT_DIR_DEFAULT
     StringCopy(.src = outputPath, .dest = options.outputPath, .size = MAX_PATH)
 
     var len = strlen(options.outputPath)


### PR DESCRIPTION
With a publicly exposed configuration file (in this case `src/config.lita`), one is able to set the defaults of some of the command line parameters, namely the `LITAC_HOME` environment variable and `-buildCmd`. It was also added parameters for the output and output directory.

The README was updated accordingly.

There was also a small change to have a default LITAC_HOME variable set on build.sh (which could/should be replicated to the `.bat` scripts).

<br>

With a file having some of the compiler configuration easily exposed (that can even be procedurally generated), I believe integrating a build system should be easier.