### PR TITLE
Implement export name control

### DIFF
--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -959,6 +959,25 @@ func (this: using *CGen) foreignName(decl: *Decl, defaultName: StringView) : Str
 public func (this: using *CGen) cName(sym: *Symbol) : *const char {
     var sb = StringBufferInit(256, this.allocator)
 
+    if(sym.flags & SymbolFlags.IS_EXPORT) {
+        var note = sym.decl.getNote("export")
+        // TODO assert note != null
+        if(!note.arguments.empty()) {
+            var arg = note.arguments.getPtr(0)
+            if(arg.argExpr.kind == StmtKind.STRING_EXPR) {
+                var strExpr = arg.argExpr as (*StringExpr)
+                sb.appendStrn(strExpr.string.str.buffer, strExpr.string.str.length)
+                return sb.cStrConst()
+            }
+            else {
+                // TODO warning "export argument should be string"
+            }
+        }
+        else {
+            // TODO warning "export without argument, using default name"
+        }
+    }
+
     var declName = sym.name.view
     if(IsFuncLike(sym.type)) {
         declName = this.escapeNameStr(sym.name)

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -959,8 +959,8 @@ func (this: using *CGen) foreignName(decl: *Decl, defaultName: StringView) : Str
 public func (this: using *CGen) cName(sym: *Symbol) : *const char {
     var sb = StringBufferInit(256, this.allocator)
 
-    if(sym.flags & SymbolFlags.IS_EXPORT) {
-        var note = sym.decl.getNote("export")
+    if(sym.flags & SymbolFlags.IS_EXTERN) {
+        var note = sym.decl.getNote("extern")
         // TODO assert note != null
         if(!note.arguments.empty()) {
             var arg = note.arguments.getPtr(0)

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -974,7 +974,7 @@ public func (this: using *CGen) cName(sym: *Symbol) : *const char {
             }
         }
         else {
-            // TODO warning "export without argument, using default name"
+            this.result.addError(note.startPos, "argument is required'")
         }
     }
 

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -970,7 +970,8 @@ public func (this: using *CGen) cName(sym: *Symbol) : *const char {
                 return sb.cStrConst()
             }
             else {
-                // TODO warning "export argument should be string"
+                // warning "export argument should be string"
+                assert(false)
             }
         }
         else {

--- a/src/config.lita
+++ b/src/config.lita
@@ -13,11 +13,11 @@
 // you can change this to point there.
 //
 // this can be overriden by the `LITAC_HOME` environment variable
-public const LITAC_HOME_DEFAULT : *const char = "";
+public const LITAC_HOME_DEFAULT : *const char = "/home/user/litac-lang";
 
 // the default -buildCmd
 // change to 'gcc' or 'tcc' if you'd prefer
-public const BUILD_CMD_DEFAULT : *const char = "clang %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS";
+public const BUILD_CMD_DEFAULT : *const char = "gcc %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS";
 
 // default -outputDir
 // this writes the output files to the current directory,

--- a/src/config.lita
+++ b/src/config.lita
@@ -13,11 +13,11 @@
 // you can change this to point there.
 //
 // this can be overriden by the `LITAC_HOME` environment variable
-public const LITAC_HOME_DEFAULT : *const char = "/home/user/litac-lang";
+public const LITAC_HOME_DEFAULT : *const char = "";
 
 // the default -buildCmd
 // change to 'gcc' or 'tcc' if you'd prefer
-public const BUILD_CMD_DEFAULT : *const char = "gcc %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS";
+public const BUILD_CMD_DEFAULT : *const char = "clang %input% -std=c99 -o %output% -D_CRT_SECURE_NO_WARNINGS";
 
 // default -outputDir
 // this writes the output files to the current directory,

--- a/src/intern.lita
+++ b/src/intern.lita
@@ -81,6 +81,7 @@ public const ALIAS = InternedString{};
 public const ASSTR = InternedString{};
 public const TOSTR = InternedString{};
 public const COMPILER_OPTION = InternedString{};
+public const EXTERN = InternedString{};
 
 public func InternHashFn(a: InternedString) : u32 {
     var hash = ((a.addr as (usize)) % 4294967291_u32) as (u32)
@@ -179,6 +180,7 @@ public func (this: *Strings) init(allocator: *const Allocator) {
     this.internConstant("asStr", 5, &ASSTR)
     this.internConstant("toStr", 5, &TOSTR)
     this.internConstant("compiler_option", 15, &COMPILER_OPTION)
+    this.internConstant("extern", 6, &EXTERN)
 
 }
 

--- a/src/symbols.lita
+++ b/src/symbols.lita
@@ -56,6 +56,9 @@ public enum SymbolFlags {
     IS_MARKED_RESET         = (1<<22),
     IS_HIDDEN               = (1<<23),
     IS_FROM_PREPROCESSOR    = (1<<24),
+
+    // To control name generation
+    IS_EXPORT               = (1<<25),
 }
 
 public const MAX_SYMBOL_NAME = 256;
@@ -319,6 +322,10 @@ public func (this: *Scope) addSymbol(name: InternedString,
 
     if(decl.hasNote("hidden")) {
         flags |= SymbolFlags.IS_HIDDEN
+    }
+
+    if(decl.hasNote("export")) {
+        flags |= SymbolFlags.IS_EXPORT
     }
 
     if(decl.attributes.isPublic) {

--- a/src/symbols.lita
+++ b/src/symbols.lita
@@ -58,7 +58,7 @@ public enum SymbolFlags {
     IS_FROM_PREPROCESSOR    = (1<<24),
 
     // To control name generation
-    IS_EXPORT               = (1<<25),
+    IS_EXTERN               = (1<<25),
 }
 
 public const MAX_SYMBOL_NAME = 256;
@@ -324,8 +324,8 @@ public func (this: *Scope) addSymbol(name: InternedString,
         flags |= SymbolFlags.IS_HIDDEN
     }
 
-    if(decl.hasNote("export")) {
-        flags |= SymbolFlags.IS_EXPORT
+    if(decl.hasNote("extern")) {
+        flags |= SymbolFlags.IS_EXTERN
     }
 
     if(decl.attributes.isPublic) {

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -90,6 +90,10 @@ public @note test {
 public @note packed {
 }
 
+public @note export {
+    value: *const char
+}
+
 //=====================================================================================
 
 /*

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -90,7 +90,7 @@ public @note test {
 public @note packed {
 }
 
-public @note export {
+public @note extern {
     value: *const char
 }
 

--- a/stdlib/std/system/system.lita
+++ b/stdlib/std/system/system.lita
@@ -465,6 +465,11 @@ public func FileParent(filename: *const char, out:[MAX_PATH]char, length: *i32 =
     }
 
 end:
+    if(index == 0) {
+        // parent directory is current directory
+        out[index] = '.';
+        index += 1;
+    }
     if(length) {
         (*length) = index
     }


### PR DESCRIPTION
this allows to manually define the name of the exported symbol, using the `@export("<name>")` note.

As per #32 

There are a few warning/errors that should be thrown, or checked in another place, let me know how you would like to proceed