### PR TITLE
Fix function ptr generic inferrence

### DIFF
--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -320,6 +320,14 @@ func (this: *TypeChecker) coerceFuncArg(expr: *FuncCallExpr,
             return false
         }
     }
+    // promote the function to a function ptr
+    else if (paramInfo.kind == TypeKind.FUNC_PTR && argInfo.kind == TypeKind.FUNC) {
+        var groupExpr = NewGroupExpr(argExpr.startPos, argExpr.endPos, argExpr, this.allocator)
+        argExpr = NewUnaryExpr(argExpr.startPos, argExpr.endPos, TokenType.BAND, groupExpr, this.allocator)
+        if(!this.resolveExpr(argExpr)) {
+            return false
+        }
+    }
 
     expr.node.becomeParentOf(argExpr)
     suppliedArgs.set(index, CallArg { .argExpr = argExpr })
@@ -382,11 +390,6 @@ func (this: *TypeChecker) inferredType(name: Identifier, paramType: *TypeInfo, e
                 break;
             }
         }
-    }
-    else if(paramType.kind == TypeKind.FUNC_PTR) {
-        // TODO: Is this even necessary? Build a test case for
-        // this..
-        assert(false)
     }
 
     switch(paramType.kind) {
@@ -512,12 +515,32 @@ func (this: *TypeChecker) inferredType(name: Identifier, paramType: *TypeInfo, e
     return null
 }
 
+func (this: *TypeChecker) checkInferrability(expr: *Expr, type: *TypeInfo) : bool {
+    // Function ptr with generic arguments can't be inferred when used as a parameter to a generic function
+    // for which we are trying to infer for, as there is nothing in the function ptr to hint for the
+    // actual type.
+
+    if(type.kind == TypeKind.FUNC && type.sym && type.sym.flags & SymbolFlags.IS_GENERIC_TEMPLATE) {
+        this.errorMissingGenericArguments(expr, type.sym.name, &type.funcDecl.genericParams)
+        return false
+    }
+    else if(type.kind == TypeKind.FUNC_PTR && !type.genericParams.empty()) {
+        this.errorMissingGenericArguments(expr, type.name, &type.genericParams)
+        return false
+    }
+    return true
+}
+
 func (this: *TypeChecker) inferFuncCallExpr(expr: *FuncCallExpr, funcType: *TypeInfo, suppliedArgs: *Array<CallArg>, isMethodCall: bool) : *TypeInfo {
     assert(IsFuncLike(funcType))
 
     for(var i = 0; i < expr.arguments.size(); i += 1) {
         var arg = expr.arguments.get(i)
         if(!this.resolveExpr(arg.argExpr)) {
+            goto err;
+        }
+
+        if(!this.checkInferrability(arg.argExpr, arg.argExpr.operand.typeInfo)) {
             goto err;
         }
     }

--- a/src/types.lita
+++ b/src/types.lita
@@ -1510,6 +1510,7 @@ public func (this: *TypeInfo) asTypeSpec(module: *Module) : *TypeSpec {
 public func (this: *TypeInfo) asPtr(typeCache: *TypeCache) : *TypeInfo {
     var genericParams = ArrayInit<GenericParam>(this.funcDecl.genericParams.size(), typeCache.allocator)
     genericParams.addAll(this.funcDecl.genericParams)
+
     var paramDecls = ArrayInit<*TypeInfo>(this.funcDecl.params.size(), typeCache.allocator)
     for(var i = 0; i < this.funcDecl.params.size() ; i += 1) {
         var p = this.funcDecl.params.get(i)

--- a/test/tests/generics_inference.json
+++ b/test/tests/generics_inference.json
@@ -12,7 +12,122 @@
         }
     `,
     "tests": [
+        {
+            "name": "Generics Type Inference for Struct as Parameter",
+            "definitions": `
 
+                struct Test<X> {
+                    a: X
+                }
+
+                func run<K>(test: Test<K>, x: K) : i32 {
+                    return test.a + x
+                }
+            `,
+            "code": `
+                assert(run(&Test{.a = 4_i32}, 8_i32) == 12)
+            `,
+        },
+        {
+            "name": "Generics Type Inference for FuncPtr as Parameter Missing",
+            "definitions": `
+
+                typedef func<K>(K) : i32 as HashFn<K>;
+                func PtrHashFn<K>(a: K) : i32 {
+                    return a + 8;
+                }
+
+                func run<K>(f: HashFn<K>, x: K) : i32 {
+                    return f(x)
+                }
+            `,
+            "code": `
+                assert(run(&PtrHashFn, 4_i32) == 12)
+            `,
+            "error": "'PtrHashFn' is missing generic arguments ['K']"
+        },
+        {
+            "name": "Generics Type Inference for FuncPtr as Parameter",
+            "definitions": `
+
+                typedef func<K>(K) : i32 as HashFn<K>;
+                func PtrHashFn<K>(a: K) : i32 {
+                    return a + 8;
+                }
+
+                func run<K>(f: HashFn<K>, x: K) : i32 {
+                    return f(x)
+                }
+            `,
+            "code": `
+                assert(run(&PtrHashFn<i32>, 4_i32) == 12)
+            `,
+        },
+        {
+            "name": "Generics Type Inference for Func as Parameter Missing",
+            "definitions": `
+
+                typedef func<K>(K) : i32 as HashFn<K>;
+                func PtrHashFn<K>(a: K) : i32 {
+                    return a + 8;
+                }
+
+                func run<K>(f: HashFn<K>, x: K) : i32 {
+                    return f(x)
+                }
+            `,
+            "code": `
+                assert(run(PtrHashFn, 4_i32) == 12)
+            `,
+            "error": "'PtrHashFn' is missing generic arguments ['K']"
+        },
+        {
+            "name": "Generics Type Inference for Func as Parameter",
+            "definitions": `
+
+                typedef func<K>(K) : i32 as HashFn<K>;
+                func PtrHashFn<K>(a: K) : i32 {
+                    return a + 8;
+                }
+
+                func run<K>(f: HashFn<K>, x: K) : i32 {
+                    return f(x)
+                }
+            `,
+            "code": `
+                assert(run(PtrHashFn<i32>, 4_i32) == 12)
+            `,
+        },
+        {
+            "name": "Generics Type Inference from Func Ptr Generic Type",
+            "definitions": `
+                func test<T>(fn: func<T>(T):T, t: T):T {
+                    return fn<T>(t)
+                }
+                func run(t: i32) : i32 {
+                    return t
+                }
+            `,
+            "code": `
+                assert(test(&run, 4) == 4)
+            `,
+        },
+        {
+            "name": "Generics Type Inference from Func Ptr Generic Type",
+            "definitions": `
+                typedef func<V>(V):V as Func<V>
+
+                func test<T>(fn: Func<T>, t: T):T {
+                    return fn<T>(t)
+                }
+                func run(t: i32) : i32 {
+                    return t
+                }
+            `,
+            "code": `
+                assert(test(&run, 4) == 4)
+            `,
+        },
         {
             "name": "Generics Type Inference",
             "definitions": `
@@ -117,21 +232,6 @@
                 assert(test(t) == 4)
             `,
         },
-        /* TODO: Fix FuncPtr
-        {
-            "name": "Generics Type Inference from Func Ptr Generic Type",
-            "definitions": `
-                func test<T>(fn: func<T>(T):T, t: T):T {
-                    return fn<T>(t)
-                }
-                func run(t: i32) : i32 {
-                    return t
-                }
-            `,
-            "code": `
-                assert(test(&run, 4) == 4)
-            `,
-        },*/
 
         {
             "name": "Generics Type Inference from Struct of Struct Generic Type multiple",
@@ -205,25 +305,6 @@
                 assert(test(t) == 4)
             `,
         },
-
-        /* TODO: Func Ptr
-        {
-            "name": "Generics Type Inference from Func Ptr Generic Type",
-            "definitions": `
-                typedef func<V>(V):V as Func<V>
-
-                func test<T>(fn: Func<T>, t: T):T {
-                    return fn<T>(t)
-                }
-                func run(t: i32) : i32 {
-                    return t
-                }
-            `,
-            "code": `
-                assert(test(&run, 4) == 4)
-            `,
-        },*/
-
 
         {
             "name": "Generics Type Inference from Union Generic Type with typedef",


### PR DESCRIPTION
There was a bug that would allow unresolved generic function pointers to go thru compilation causing errors.  This fix disallows function pointers with unresolved generic parameters from being used for generic type inferrence.

Example:

```
typedef func<K>(K) : i32 as HashFn<K>;
func PtrHashFn<K>(a: K) : i32 {
    return a + 8;
}

func run<K>(f: HashFn<K>, x: K) : i32 {
    return f(x)
}

// Here we can not properly infer the generic <K> type from the PtrHashFn, or at least how the compiler
// is currently constructed.  This would require the compiler to pause full type inferrence for PtrHashFn until
// is resolved all other parameters, and if run could be fully inferred, then use those inferred generic arguments
// to resolve PtrHashFn.
//
// Giving this is a significant enhancement to the compiler, I opted to just not allow it and require explicit 
// type arguments: PtrHashFn<i32>
assert(run(&PtrHashFn, 4_i32) == 12) // invalid type inferrence
assert(run(&PtrHashFn<i32>, 4_i32) == 12) // valid type inferrence
```