### PR TITLE
Add internal visibility modifier

### DIFF
--- a/src/ast.lita
+++ b/src/ast.lita
@@ -145,8 +145,19 @@ public struct GenericParam {
     name: Identifier
 }
 
+public enum Visibility {
+    /* Only visibility within the defined module -- this is the default */
+    PRIVATE,
+
+    /* Visible to all modules defined in the folder and sub-folders */
+    INTERNAL,
+
+    /* Visible to all */
+    PUBLIC,
+}
+
 public struct Attributes {
-    isPublic: bool
+    visibility: Visibility = Visibility.PRIVATE
     isGlobal: bool
     isUsing: bool
     notes: Array<*NoteStmt>

--- a/src/ast_print.lita
+++ b/src/ast_print.lita
@@ -148,8 +148,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
             }
 
             Printf(indent, "")
-            if(decl.attributes.isPublic) {
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
                 printf("public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                printf("internal ")
             }
             printf("struct ")
             PrintName(decl.name.token)
@@ -200,8 +203,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
             }
 
             Printf(indent, "")
-            if(decl.attributes.isPublic) {
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
                 printf("public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                printf("internal ")
             }
             printf("union ")
             PrintName(decl.name.token)
@@ -252,8 +258,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
             }
 
             Printf(indent, "")
-            if(decl.attributes.isPublic) {
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
                 printf("public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                printf("internal ")
             }
             printf("trait ")
             PrintName(decl.name.token)
@@ -291,8 +300,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
             }
 
             Printf(indent, "")
-            if(decl.attributes.isPublic) {
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
                 printf("public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                printf("internal ")
             }
             printf("enum ")
             PrintName(decl.name.token)
@@ -314,8 +326,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
                 }
             }
 
-            if(decl.attributes.isPublic) {
-                Printf(indent, "public ")
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
+                printf("public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                printf("internal ")
             }
             Printf(indent, "func ")
             PrintName(decl.name.token)
@@ -354,8 +369,11 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
                 }
             }
 
-            if(decl.attributes.isPublic) {
+            if(decl.attributes.visibility == Visibility.PUBLIC) {
                 Printf(indent, "public ")
+            }
+            else if(decl.attributes.visibility == Visibility.INTERNAL) {
+                Printf(indent, "internal ")
             }
             Printf(indent, "typedef ")
             PrintTypeSpec(decl.type)

--- a/src/ast_print.lita
+++ b/src/ast_print.lita
@@ -327,10 +327,10 @@ public func PrintStmt(s: *Stmt, indent: i32 = 0) {
             }
 
             if(decl.attributes.visibility == Visibility.PUBLIC) {
-                printf("public ")
+                Printf(indent, "public ")
             }
             else if(decl.attributes.visibility == Visibility.INTERNAL) {
-                printf("internal ")
+                Printf(indent, "internal ")
             }
             Printf(indent, "func ")
             PrintName(decl.name.token)

--- a/src/lex.lita
+++ b/src/lex.lita
@@ -63,6 +63,7 @@ public enum TokenType {
 
     AS,
     PUBLIC,
+    INTERNAL,
     USING,
     // End KeyWords
 
@@ -185,6 +186,7 @@ public const tokenText = [TokenType.MAX_TOKEN_TYPES]*const char {
 
     [TokenType.AS] = "as",
     [TokenType.PUBLIC] = "public",
+    [TokenType.INTERNAL] = "internal",
     [TokenType.USING] = "using",
 
     // End KeyWords
@@ -362,6 +364,7 @@ const keywordCache = [MAX_KEYWORD_CACHE]**const char {
     [8] = []*const char {
         "continue",
         "offsetof",
+        "internal",
         null
     },
 }
@@ -426,6 +429,7 @@ const keywordCacheIndex = [MAX_KEYWORD_CACHE]*TokenType {
     [8] = []TokenType {
         TokenType.CONTINUE,
         TokenType.OFFSETOF,
+        TokenType.INTERNAL,
     }
 }
 

--- a/src/module.lita
+++ b/src/module.lita
@@ -345,9 +345,15 @@ public func (this: *Module) importModuleSymbol(importSrcPos: SrcPos,
                                                symName: InternedString,
                                                isUsing: bool) {
 
-    // only import public symbols
-    if(!(symbol.flags & SymbolFlags.IS_PUBLIC)) {
+    // only import public/internal symbols
+    if(symbol.flags & SymbolFlags.IS_PRIVATE) {
         return;
+    }
+
+    if(symbol.flags & SymbolFlags.IS_INTERNAL) {
+        if(!this.isInPackage(moduleToImport)) {
+            return;
+        }
     }
 
     // only import symbols that are declared in the import module
@@ -400,6 +406,48 @@ public func (this: *Module) equals(other: *Module) : bool {
     if(this == other) return true
     return strcmp(this.id.filename, other.id.filename) == 0
     */
+}
+
+@doc("""
+    Checks to see if the supplied module is within this package
+""")
+public func (this: *Module) isInPackage(other: *Module) : bool {
+    //printf("This: %.*s vs Other: %.*s\n", this.id.packageName.length, this.id.packageName.buffer,
+    //    other.id.packageName.length, other.id.packageName.buffer)
+
+    if(this == other) {
+        return true
+    }
+
+    // check if other is a sub-package of this
+    {
+        var rootIndex = this.id.packageName.view.lastIndexOfAt("::", 2)
+        if(rootIndex < 0) {
+            return true
+        }
+
+        var root = this.id.packageName.view.substring(0, rootIndex)
+        var result = other.id.packageName.view.startsWith(root.buffer, root.length);
+        if(result) {
+            return true
+        }
+    }
+
+    // check if this is a sub-package of other
+    {
+        var rootIndex = other.id.packageName.view.lastIndexOfAt("::", 2)
+        if(rootIndex < 0) {
+            return true
+        }
+
+        var root = other.id.packageName.view.substring(0, rootIndex)
+        var result = this.id.packageName.view.startsWith(root.buffer, root.length);
+        if(result) {
+            return true
+        }
+    }
+
+    return false;
 }
 
 public func (this: *Module) print(header: *const char) {

--- a/src/parser.lita
+++ b/src/parser.lita
@@ -21,11 +21,12 @@ import "module"
 import "intern"
 import "preprocessor"
 
-const DECL_ADJUST_TOKENS_COUNT = 11
+const DECL_ADJUST_TOKENS_COUNT = 12
 const DECL_ADJUST_TOKENS = [DECL_ADJUST_TOKENS_COUNT]TokenType {
     TokenType.IMPORT,
     TokenType.HASH,
     TokenType.PUBLIC,
+    TokenType.INTERNAL,
     TokenType.VAR,
     TokenType.CONST,
     TokenType.FUNC,
@@ -40,6 +41,7 @@ const STMT_ADJUST_TOKENS = []TokenType {
     TokenType.IMPORT,
     TokenType.HASH,
     TokenType.PUBLIC,
+    TokenType.INTERNAL,
     TokenType.VAR,
     TokenType.CONST,
     TokenType.FUNC,
@@ -183,7 +185,14 @@ func (p: *Parser) parseModuleDeclaration(moduleStmt: *ModuleStmt) {
             return;
         }
 
-        var isPublic = p.match(TokenType.PUBLIC)
+        var visibility = Visibility.PRIVATE
+        if(p.match(TokenType.INTERNAL)) {
+            visibility = Visibility.INTERNAL
+        }
+        else if(p.match(TokenType.PUBLIC)) {
+            visibility = Visibility.PUBLIC
+        }
+
         if(p.match(TokenType.VAR)) {
             var decl = p.varDeclaration()
             moduleStmt.declarations.add(decl)
@@ -233,7 +242,7 @@ func (p: *Parser) parseModuleDeclaration(moduleStmt: *ModuleStmt) {
 
         var decl = moduleStmt.declarations.last()
         decl.attributes.notes = notes
-        decl.attributes.isPublic = isPublic
+        decl.attributes.visibility = visibility
         decl.attributes.isGlobal = true
     }
 }
@@ -256,7 +265,14 @@ func (p: *Parser) parseCompileTimeBody() : *Stmt {
             goto err;
         }
 
-        var isPublic = p.match(TokenType.PUBLIC)
+        var visibility = Visibility.PRIVATE
+        if(p.match(TokenType.INTERNAL)) {
+            visibility = Visibility.INTERNAL
+        }
+        else if(p.match(TokenType.PUBLIC)) {
+            visibility = Visibility.PUBLIC
+        }
+
         var decl: *Decl = null
 
         if(p.match(TokenType.VAR)) {
@@ -298,7 +314,7 @@ func (p: *Parser) parseCompileTimeBody() : *Stmt {
         }
 
         decl.attributes.notes = notes
-        decl.attributes.isPublic = isPublic
+        decl.attributes.visibility = visibility
         decl.attributes.isGlobal = true
 
         return decl as (*Stmt);

--- a/src/preprocessor/api.lita
+++ b/src/preprocessor/api.lita
@@ -356,7 +356,9 @@ func (this: *Preprocessor) declToApe(sym: *Symbol) : ape_object_t {
     ape_object_set_map_value(declObj, "packageName",
         ape_object_make_stringf(this.runtime.ape, "%.*s", sym.declared.id.packageName.length, sym.declared.id.packageName.buffer))
 
-    ape_object_set_map_value(declObj, "isPublic", ape_object_make_bool(sym.decl.attributes.isPublic))
+    ape_object_set_map_value(declObj, "isPublic", ape_object_make_bool(sym.decl.attributes.visibility == Visibility.PUBLIC))
+    ape_object_set_map_value(declObj, "isInternal", ape_object_make_bool(sym.decl.attributes.visibility == Visibility.INTERNAL))
+    ape_object_set_map_value(declObj, "isPrivate", ape_object_make_bool(sym.decl.attributes.visibility == Visibility.PRIVATE))
     ape_object_set_map_value(declObj, "isGlobal", ape_object_make_bool(sym.decl.attributes.isGlobal))
     ape_object_set_map_value(declObj, "declPtr", ape_object_make_external(this.runtime.ape, sym.decl))
 

--- a/src/symbols.lita
+++ b/src/symbols.lita
@@ -41,21 +41,24 @@ public enum SymbolFlags {
     IS_FROM_GENERIC_TEMPLATE= (1<<9),
     IS_IMPORTED             = (1<<10),
     IS_PUBLIC               = (1<<11),
-    IS_EMITTED              = (1<<12),
-    IS_TEST                 = (1<<13),
-    IS_ALIAS                = (1<<14),
-    IS_MAIN                 = (1<<15),
-    IS_METHOD               = (1<<16),
-    IS_TRAIT                = (1<<17),
-    IS_TRAIT_METHOD         = (1<<18),
-    IS_TRAIT_GENERATED      = (1<<19),
-    IS_GENERATED            = (1<<20),
-    IS_NOTE                 = (1<<21),
+    IS_INTERNAL             = (1<<12),
+    IS_PRIVATE              = (1<<13),
+    IS_EMITTED              = (1<<14),
+    IS_TEST                 = (1<<15),
+    IS_ALIAS                = (1<<16),
+    IS_MAIN                 = (1<<17),
+    IS_METHOD               = (1<<18),
+    IS_TRAIT                = (1<<19),
+    IS_TRAIT_METHOD         = (1<<20),
+    IS_TRAIT_GENERATED      = (1<<21),
+    IS_GENERATED            = (1<<22),
+    IS_NOTE                 = (1<<23),
 
     // Marked for reset for incremental compliation
-    IS_MARKED_RESET         = (1<<22),
-    IS_HIDDEN               = (1<<23),
-    IS_FROM_PREPROCESSOR    = (1<<24),
+    IS_MARKED_RESET         = (1<<24),
+    IS_HIDDEN               = (1<<25),
+    IS_FROM_PREPROCESSOR    = (1<<26),
+
 }
 
 public const MAX_SYMBOL_NAME = 256;
@@ -321,8 +324,15 @@ public func (this: *Scope) addSymbol(name: InternedString,
         flags |= SymbolFlags.IS_HIDDEN
     }
 
-    if(decl.attributes.isPublic) {
-        flags |= SymbolFlags.IS_PUBLIC
+    switch(decl.attributes.visibility) {
+        case Visibility.PUBLIC:
+            flags |= SymbolFlags.IS_PUBLIC
+            break;
+        case Visibility.INTERNAL:
+            flags |= SymbolFlags.IS_INTERNAL
+            break;
+        default:
+            flags |= SymbolFlags.IS_PRIVATE
     }
 
     if(isNewType) {

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -142,6 +142,9 @@ public @note packed {
             if(sym.isPublic) {
                 emit("public ")
             }
+            else if(sym.isInternal) {
+                emit("internal ")
+            }
             emit("func %s(enumType: %s) : *const char {
                       switch(enumType) {\n", symName, sym.name);
             for(field in sym.enumDecl.fields) {

--- a/test/test_suite.lita
+++ b/test/test_suite.lita
@@ -9,6 +9,7 @@ import "std/mem"
 import "std/mem/linear_allocator"
 import "std/map"
 import "std/string_buffer"
+import "std/string_view"
 import "std/string"
 import "std/system"
 
@@ -75,6 +76,7 @@ func main(len: i32, args: **char) : i32 {
         //"../test/tests/notes.json",
         // "../test/tests/misc.json", json syntax error
 
+        "../test/tests/visibility_modifiers.json",
         "../test/tests/to_json.json",
         "../test/tests/from_json.json",
         "../test/tests/static_if.json",
@@ -309,8 +311,21 @@ func RunTest(suite: *TestSuite, test: *Test) : TestResult {
     var moduleFilenameStr = StringInit(moduleFilename, 260, 0)
     for(var i = 0; i < test.modules.size(); i += 1) {
         var m = test.modules.get(i)
+        var moduleName = StringViewInit(m.name)
+
+        // make sub directories
+        if(moduleName.contains("/")) {
+            var path = moduleName.substring(0, moduleName.lastIndexOfAt("/", 1))
+
+            moduleFilenameStr.clear()
+            moduleFilenameStr.format("test_output/%.*s", path.length, path.buffer)
+            Mkdirs(moduleFilenameStr.cStr())
+        }
+
         moduleFilenameStr.clear()
         moduleFilenameStr.format("test_output/%s.lita", m.name)
+
+
         if(WriteFile(moduleFilenameStr.cStr(), m.code, strlen(m.code)) != FileStatus.Ok) {
             return TestResult.LOADING_ERROR
         }

--- a/test/tests/visibility_modifiers.json
+++ b/test/tests/visibility_modifiers.json
@@ -1,0 +1,253 @@
+{
+    "description": "Tests Visibility Modifiers",
+    "program": `
+        @include("assert.h");
+        @foreign func assert(e:bool):void;
+
+        %definitions%
+
+        func main(len:i32, args:**char):i32 {
+            %code%
+        }
+    `,
+    "tests": [
+        {
+            "name": "Test Public Modifier",
+            "definitions": `
+                import "public_module";
+            `,
+            "code": `
+                var publicStruct = TestPublicStruct {
+                    .a = 4
+                }
+                assert(publicStruct.testPublicMethod() == 4)
+            `,
+            "modules": [
+                {
+                    "name" : "public_module",
+                    "program" : `
+                        public struct TestPublicStruct {
+                            a: i32
+                        }
+
+                        public func (this: *TestPublicStruct) testPublicMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                },
+            ],
+        },
+        {
+            "name": "Test Internal Modifier",
+            "definitions": `
+                import "internal_module";
+            `,
+            "code": `
+                var internalStruct = TestStruct {
+                    .a = 4
+                }
+                assert(false)
+            `,
+            "error" : "unknown type 'TestStruct'",
+            "modules": [
+                {
+                    "name" : "sub/internal_module",
+                    "program" : `
+                        internal struct TestStruct {
+                            a: i32
+                        }
+
+                        internal func (this: *TestStruct) testMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                }
+            ],
+        },
+        {
+            "name": "Test Private Modifier",
+            "definitions": `
+                import "private_module";
+            `,
+            "code": `
+                var privateStruct = TestStruct {
+                    .a = 4
+                }
+                assert(false)
+            `,
+            "error" : "unknown type 'TestStruct'",
+            "modules": [
+                {
+                    "name" : "private_module",
+                    "program" : `
+                        struct TestStruct {
+                            a: i32
+                        }
+
+                        func (this: *TestStruct) testMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                }
+            ],
+        },
+        {
+            "name": "Test Internal Modifier is Visible to sub module",
+            "definitions": `
+                import "sub/public_module"
+
+                internal struct TestInternalStruct {
+                    a: i32
+                }
+
+                internal func (this: *TestInternalStruct) testInternalMethod() : i32 {
+                    return this.a
+                }
+            `,
+            "code": `
+
+                assert(test() == 4)
+            `,
+            "modules": [
+                {
+                    "name" : "sub/public_module",
+                    "program" : `
+                        import "lita_test";
+                        import "std/assert";
+
+                        public func test() : i32 {
+                            var internalStruct = TestInternalStruct {
+                                .a = 4
+                            }
+                            assert(internalStruct.testInternalMethod() == 4)
+                            return internalStruct.a
+                        }
+                    `
+                }
+            ],
+        },
+        {
+            "name": "Test Internal Modifier is Visible to module",
+            "definitions": `
+                import "public_module"
+
+                internal struct TestInternalStruct {
+                    a: i32
+                }
+
+                internal func (this: *TestInternalStruct) testInternalMethod() : i32 {
+                    return this.a
+                }
+            `,
+            "code": `
+
+                assert(test() == 4)
+            `,
+            "modules": [
+                {
+                    "name" : "public_module",
+                    "program" : `
+                        import "lita_test";
+                        import "std/assert";
+
+                        public func test() : i32 {
+                            var internalStruct = TestInternalStruct {
+                                .a = 4
+                            }
+                            assert(internalStruct.testInternalMethod() == 4)
+                            return internalStruct.a
+                        }
+                    `
+                }
+            ],
+        },
+        {
+            "name": "Test Private Modifier is Visible to sub module",
+            "definitions": `
+                import "public_module"
+
+                struct TestPrivateStruct {
+                    a: i32
+                }
+
+                func (this: *TestPrivateStruct) testPrivateMethod() : i32 {
+                    return this.a
+                }
+            `,
+            "code": `
+                assert(false)
+            `,
+            "error": "unknown type 'TestPrivateStruct'",
+            "modules": [
+                {
+                    "name" : "public_module",
+                    "program" : `
+                        import "test_module";
+                        import "std/assert";
+
+                        public func test() : i32 {
+                            var privateStruct = TestPrivateStruct {
+                                .a = 4
+                            }
+                            assert(privateStruct.testPrivateMethod() == 4)
+                            return privateStruct.a
+                        }
+                    `
+                }
+            ],
+        },
+        {
+            "name": "Test Public Modifier",
+            "definitions": `
+                import "public_module";
+                import "internal_module";
+                import "private_module";
+            `,
+            "code": `
+                var publicStruct = TestPublicStruct {
+                    .a = 4
+                }
+                assert(publicStruct.testPublicMethod() == 4)
+            `,
+            "modules": [
+                {
+                    "name" : "public_module",
+                    "program" : `
+                        public struct TestPublicStruct {
+                            a: i32
+                        }
+
+                        public func (this: *TestPublicStruct) testPublicMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                },
+                {
+                    "name" : "internal_module",
+                    "program" : `
+                        internal struct TestInternalStruct {
+                            a: i32
+                        }
+
+                        internal func (this: *TestInternalStruct) testInternalMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                },
+                {
+                    "name" : "private_module",
+                    "program" : `
+                        struct TestPrivateStruct {
+                            a: i32
+                        }
+
+                        func (this: *TestPrivateStruct) testPrivateMethod() : i32 {
+                            return this.a
+                        }
+                    `
+                }
+            ],
+        },
+
+    ]
+}


### PR DESCRIPTION
Adds the `internal` visibility modifier which allows for package visibility for declarations.  This means, any module within the same folder or sub-folder can see a declaration defined with `internal` visibility modifier.  No modifier (aka `private`) declarations are only visible within a module.  A `public` visibility modifier means any module can see the declaration.