### PR TITLE
Create the pkg-init command

### DIFF
--- a/src/lita.lita
+++ b/src/lita.lita
@@ -101,12 +101,15 @@ public enum PkgCommand {
     PKG_NONE = 0,
     PKG_INSTALL,
     PKG_RUN,
+    PKG_INIT,
 }
 
 public struct PkgOptions {
     pkgCmd: PkgCommand             // the Package Manager command we're running (if any)
     pkgRunCmdArg: *const char      // the pkg-run {arg} argument
     forceClean: bool               // force cleaning of package directories
+
+    pkgName: *const char           // pkg-init options
 }
 
 public struct LitaOptions {

--- a/src/main.lita
+++ b/src/main.lita
@@ -179,6 +179,7 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     parser.addOption("pkg-install",    '\0', "Scans for a pkg.json file and downloads and installs LitaC packages defined in the `dependencies` section.\nIf successful, creates a build.json which is used for building this LitaC project.", 0, null);
     parser.addOption("force",          '\0', "Forces a full clean install of all packages.  Must be ran with `pkg-install` option, otherwise will be ignored.", 0, null);
     parser.addOption("pkg-run",        '\0', "Runs a script defined in the `commands` section in this projects `pkg.json`.  The argument passed of this option is used to run the `commands.{option}` command", OptionFlag.HAS_ARGUMENT, null);
+    parser.addOption("pkg-init",       '\0', "Initializes a new LitaC package project", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("proxy",          '\0', "Defines a proxy server to use when making network calls.  Ex. -proxy https://proxy.com:443", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("buildCmd",       'b',  "The underlying C compiler build and compile command.  Variables will be substituted if found:\n%output%\tThe executable name\n%input%\tThe file(s) generated.\n%options%\tThe generated @compiler_option's if -strict option is enabled. \nOtherwise, the LitaC compiler will append any @compiler_option flags to this command.", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("strict",         '\0', "The LitaC compiler will not modify the `buildCmd` option (for applying @compiler_option), instead it will store the generated @compiler_options in the %options% substitution variable.", 0, null);
@@ -216,6 +217,11 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     if(parser.hasOption("pkg-run")) {
         options.pkgOptions.pkgCmd = PkgCommand.PKG_RUN
         options.pkgOptions.pkgRunCmdArg = parser.getOption("pkg-run").value
+    }
+
+    if(parser.hasOption("pkg-init")) {
+        options.pkgOptions.pkgCmd = PkgCommand.PKG_INIT
+        options.pkgOptions.pkgName = parser.getOption("pkg-init").value
     }
 
     options.languageServer = parser.hasOption("languageServer")
@@ -390,6 +396,9 @@ func HandlePkgCommand(options: *LitaOptions) : i32 {
         case PkgCommand.PKG_RUN: {
             return RunPkgCommand(options, &pm)
         }
+        case PkgCommand.PKG_INIT: {
+            return RunPkgInit(options, &pm)
+        }
         default:
             return 0;
     }
@@ -436,6 +445,19 @@ func RunPkgCommand(options: *LitaOptions, pm: *PackageManager) : i32 {
     var status = pm.runCommand(options.pkgOptions.pkgRunCmdArg)
     if(status != PkgStatus.OK) {
         printf("Error running pkg command:\nErrorCode: %s - %s\n",
+            PkgStatusAsStr(status), pm.errors.cStr())
+        return 1;
+    }
+    return 0;
+}
+
+
+func RunPkgInit(options: *LitaOptions, pm: *PackageManager) : i32 {
+    var status = pm.initCommand(PackageInitOptions {
+        .name = options.pkgOptions.pkgName
+    })
+    if(status != PkgStatus.OK) {
+        printf("Error running pkg init:\nErrorCode: %s - %s\n",
             PkgStatusAsStr(status), pm.errors.cStr())
         return 1;
     }

--- a/src/pkg_mgr/pkg_init.lita
+++ b/src/pkg_mgr/pkg_init.lita
@@ -1,0 +1,80 @@
+import "pkg_mgr"
+import "std/system"
+import "std/string"
+import "std/string_buffer"
+import "std/array"
+import "std/json"
+import "std/libc"
+import "std/io"
+
+
+public func PackageInit(pm: *PackageManager, options: PackageInitOptions) : PkgStatus {
+
+    printf("Project Dir: %s\n", pm.options.projectPath)
+    printf("Name: %s\n", options.name)
+    printf("Version: %s\n", options.version)
+    printf("Type: %s\n", options.type)
+    printf("Repo: %s\n", options.repo)
+
+    const MAX_BUFFER = 1024
+    var buffer = [MAX_BUFFER]char{};
+    var path = StringInit(buffer, MAX_BUFFER, 0)
+
+    path.format("%s/bin", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/doc", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/lib", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/src", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+
+    var sb = StringBufferInit(1024)
+    defer sb.free()
+    {
+        sb.append("%s",
+"""
+import "std/libc"
+
+func main(len: i32, args: **char) : i32 {
+    printf("Hello World")
+}
+""")
+
+        path.format("%s/src/main.lita", pm.options.projectPath)
+        WriteFile(path.cStr(), sb.buffer, sb.length)
+    }
+
+    {
+        sb.clear().append("""
+{
+    "name" : "%s",
+    "version" : "%s",
+    "type" : "%s",
+    "repo" : "%s",
+
+    "build_command" : {
+        "default" : {
+            "default" : {
+                "build_cmd" : "clang.exe -std=c99 -fsanitize=undefined,address %%input%% -o %%output%%  -D_CRT_SECURE_NO_WARNINGS",
+                "lita_options" : ""
+            }
+        }
+    },
+
+    "dependencies": [],
+
+}
+""" // TODO: Json escape strings...
+        , options.name, options.version, options.type, options.repo)
+
+        path.format("%s/pkg.json", pm.options.projectPath)
+        WriteFile(path.cStr(), sb.buffer, sb.length)
+    }
+
+    return PkgStatus.OK
+}

--- a/src/pkg_mgr/pkg_init.lita
+++ b/src/pkg_mgr/pkg_init.lita
@@ -9,13 +9,6 @@ import "std/io"
 
 
 public func PackageInit(pm: *PackageManager, options: PackageInitOptions) : PkgStatus {
-
-    printf("Project Dir: %s\n", pm.options.projectPath)
-    printf("Name: %s\n", options.name)
-    printf("Version: %s\n", options.version)
-    printf("Type: %s\n", options.type)
-    printf("Repo: %s\n", options.repo)
-
     const MAX_BUFFER = 1024
     var buffer = [MAX_BUFFER]char{};
     var path = StringInit(buffer, MAX_BUFFER, 0)
@@ -32,9 +25,14 @@ public func PackageInit(pm: *PackageManager, options: PackageInitOptions) : PkgS
     path.format("%s/src", pm.options.projectPath)
     Mkdir(path.cStr())
 
+    path.format("%s/test", pm.options.projectPath)
+    Mkdir(path.cStr())
+
 
     var sb = StringBufferInit(1024)
     defer sb.free()
+
+    // Write out main.lita
     {
         sb.append("%s",
 """
@@ -46,9 +44,31 @@ func main(len: i32, args: **char) : i32 {
 """)
 
         path.format("%s/src/main.lita", pm.options.projectPath)
-        WriteFile(path.cStr(), sb.buffer, sb.length)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
     }
 
+    // Write out main_test.lita
+    {
+        sb.clear().append("%s",
+"""
+import "main"
+
+@test("project_test")
+func test() {
+    assert(true)
+}
+
+""")
+
+        path.format("%s/test/main_test.lita", pm.options.projectPath)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
+    }
+
+    // Write out pkg.json
     {
         sb.clear().append("""
 {
@@ -60,7 +80,8 @@ func main(len: i32, args: **char) : i32 {
     "build_command" : {
         "default" : {
             "default" : {
-                "build_cmd" : "clang.exe -std=c99 -fsanitize=undefined,address %%input%% -o %%output%%  -D_CRT_SECURE_NO_WARNINGS",
+                "cc" : "clang",
+                "cc_options" : "-std=c99 -fsanitize=undefined,address %%input%% -o %%output%% -D_CRT_SECURE_NO_WARNINGS",
                 "lita_options" : ""
             }
         }
@@ -73,7 +94,9 @@ func main(len: i32, args: **char) : i32 {
         , options.name, options.version, options.type, options.repo)
 
         path.format("%s/pkg.json", pm.options.projectPath)
-        WriteFile(path.cStr(), sb.buffer, sb.length)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
     }
 
     return PkgStatus.OK

--- a/src/pkg_mgr/pkg_mgr.lita
+++ b/src/pkg_mgr/pkg_mgr.lita
@@ -142,6 +142,7 @@ public enum PkgStatus {
     ERROR_HTTP_STATUS,
     ERROR_INVALID_DIRECTORY,
     ERROR_INVALID_REPO,
+    ERROR_INIT_PACKAGE,
 }
 
 public struct PackageManager {

--- a/src/pkg_mgr/pkg_mgr.lita
+++ b/src/pkg_mgr/pkg_mgr.lita
@@ -102,6 +102,7 @@ import "std/string_view"
 import "pkg_mgr/pkg"
 import "pkg_mgr/pkg_install"
 import "pkg_mgr/pkg_run"
+import "pkg_mgr/pkg_init"
 
 import "build"
 
@@ -110,6 +111,14 @@ public struct PackageSyncOptions {
     pkgDir: *const char = ".pkgs"       // the .pkgs directory
     fullSync: bool = false              // force a full download of all packages
     httpOptions: HttpOptions            // http options
+}
+
+
+public struct PackageInitOptions {
+    name: *const char
+    version: *const char = "0.0.1"
+    type: *const char = "executable"
+    repo: *const char = ""
 }
 
 @asStr
@@ -182,6 +191,14 @@ func (this: *PackageManager) printMessages() {
     if(this.errors.length > 0) {
         printf("Error: %s\n", this.errors.cStr())
     }
+}
+
+@doc("""
+    Initializes a new LitaC project, writing out scaffolding files
+""")
+public func (this: *PackageManager) initCommand(options: PackageInitOptions) : PkgStatus {
+    defer this.printMessages()
+    return PackageInit(this, options)
 }
 
 @doc("""

--- a/stdlib/std/string_buffer.lita
+++ b/stdlib/std/string_buffer.lita
@@ -337,8 +337,9 @@ public func (b: *StringBuffer) size() : i32 {
 }
 
 @inline
-public func (b: *StringBuffer) clear() {
+public func (b: *StringBuffer) clear() : *StringBuffer {
     b.length = 0
+    return b
 }
 
 public func (b: *StringBuffer) cStrConst() : *const char {


### PR DESCRIPTION
Allows for creating a scaffolding LitaC project.  This will create the following:

```
bin/              // building will place built binary files here
src/main.lita     // source directory
docs/             // generated documents
lib/              // any static libraries
test/             // tests for the project
pkg.json          // package configuration file
```

Starts to address #37 