### PR TITLE
Build out pkg-build command

### DIFF
--- a/src/checker.lita
+++ b/src/checker.lita
@@ -1084,7 +1084,6 @@ func (this: *TypeChecker) resolveNoteTypeSpec(spec: *TypeSpec) : *TypeInfo {
         return spec.typeInfo
     }
 
-    // TODO: This creates conflicts if notes name collide with functions
     var sym = this.getType(spec, SearchType.NOTE)
     if(!sym || !sym.type) {
         this.result.addError(spec.pos, "unknown note type '%.*s'", spec.name.length, spec.name.buffer)

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -928,18 +928,23 @@ public func (this: *TypeChecker) finishResolveSymbol(sym: *Symbol) {
     }
 }
 
-public func (this: *TypeChecker) getType(spec: *TypeSpec, isFunc: bool = false) : *Symbol {
-    assert(spec != null)
-    return this.getTypeByName(spec.name, isFunc)
+public enum SearchType {
+    TYPE,
+    FUNC,
+    NOTE
 }
 
-public func (this: *TypeChecker) getTypeByName(typeName: InternedString, isFunc: bool = false) : *Symbol {
-    var type = isFunc ? this.current.getFuncType(typeName) :
-                            this.current.getType(typeName)
+public func (this: *TypeChecker) getType(spec: *TypeSpec, searchType: SearchType = SearchType.TYPE) : *Symbol {
+    assert(spec != null)
+    return this.getTypeByName(spec.name, searchType)
+}
+
+public func (this: *TypeChecker) getTypeByName(typeName: InternedString, searchType: SearchType = SearchType.TYPE) : *Symbol {
+
+    var type = GetTypeFromModule(this.current, typeName, searchType)
     if(!type) {
         if(this.genericContext.callsite) {
-            type = isFunc ? this.genericContext.callsite.getFuncType(typeName) :
-                                this.genericContext.callsite.getType(typeName)
+            type = GetTypeFromModule(this.genericContext.callsite, typeName, searchType)
         }
     }
 
@@ -965,8 +970,24 @@ public func (this: *TypeChecker) getTypeByName(typeName: InternedString, isFunc:
         var namePart = name.substring(index + 2)
 
         var namePartType = this.lita.strings.internCopy(namePart.buffer, namePart.length)
-        return isFunc ? module.getFuncType(namePartType) :
-                            module.getType(namePartType)
+        return GetTypeFromModule(module, namePartType, searchType)
+    }
+
+    return type
+}
+
+func GetTypeFromModule(module: *Module, typeName: InternedString, searchType: SearchType) : *Symbol {
+    var type: *Symbol = null;
+    switch(searchType) {
+        case SearchType.FUNC:
+            type = module.getFuncType(typeName)
+            break;
+        case SearchType.NOTE:
+            type = module.getNoteType(typeName)
+            break;
+        default:
+            type = module.getType(typeName)
+            break;
     }
 
     return type
@@ -1064,13 +1085,12 @@ func (this: *TypeChecker) resolveNoteTypeSpec(spec: *TypeSpec) : *TypeInfo {
     }
 
     // TODO: This creates conflicts if notes name collide with functions
-    var sym = this.getType(spec, false)
+    var sym = this.getType(spec, SearchType.NOTE)
     if(!sym || !sym.type) {
         this.result.addError(spec.pos, "unknown note type '%.*s'", spec.name.length, spec.name.buffer)
         goto err;
     }
 
-    /* TODO: Silence until bootstrap is completed */
     if(!(sym.flags & SymbolFlags.IS_NOTE)) {
         this.result.addError(spec.pos, "'%.*s' is not a note type", spec.name.length, spec.name.buffer)
         goto err;
@@ -1089,7 +1109,7 @@ err:
     return &POISON_TYPE
 }
 
-public func (this: *TypeChecker) resolveTypeSpec(spec: *TypeSpec, isFunc: bool = false) : *TypeInfo {
+public func (this: *TypeChecker) resolveTypeSpec(spec: *TypeSpec, searchType: SearchType = SearchType.TYPE) : *TypeInfo {
     if(!spec) {
         return &VOID_TYPE
     }
@@ -1107,7 +1127,7 @@ public func (this: *TypeChecker) resolveTypeSpec(spec: *TypeSpec, isFunc: bool =
                 return nameSpec.typeInfo
             }
 
-            var sym = this.getType(nameSpec, isFunc)
+            var sym = this.getType(nameSpec, searchType)
             if(!sym) {
                 sym = this.currentScope().lookup(nameSpec.name)
                 if(!sym) {

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -134,7 +134,7 @@ public func (this: *TypeChecker) resolveExpr(expr: *Expr) : bool {
 func (this: *TypeChecker) resolveFuncIdentifierExpr(expr: *IdentifierExpr) : bool {
     assert(expr != null)
 
-    var type = this.resolveTypeSpec(expr.type, .isFunc = true)
+    var type = this.resolveTypeSpec(expr.type, SearchType.FUNC)
     if(!type) {
         this.result.addError(expr.startPos, "unknown function '%.*s'", expr.type.name.length, expr.type.name.buffer)
         return false
@@ -1534,14 +1534,14 @@ func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, type: *TypeInfo) : boo
     // if this is a generic symbol and must be re-resolved - this happens
     // during type inference for methods -- @see resolveFuncCallExpr and inferFuncCallExpr
     if(expr.flags & GetExprFlags.IS_METHOD_CALL) {
-        var funcSym = this.getType(expr.field.type, .isFunc = true)
+        var funcSym = this.getType(expr.field.type, SearchType.FUNC)
         if(!funcSym) {
             // TODO: mark an error?
             return false
         }
 
         if(funcSym.flags & SymbolFlags.IS_GENERIC_TEMPLATE) {
-            var typeInfo = this.resolveTypeSpec(expr.field.type, .isFunc = true)
+            var typeInfo = this.resolveTypeSpec(expr.field.type, SearchType.FUNC)
             if(!typeInfo) {
                 // TODO: mark an error?
                 return false;
@@ -1578,7 +1578,7 @@ func (this: *TypeChecker) checkMethodExpr(expr: *GetExpr, type: *TypeInfo) : boo
         }
 
         if(funcSym.flags & SymbolFlags.IS_GENERIC_TEMPLATE) {
-            typeInfo = this.resolveTypeSpec(expr.field.type, .isFunc = true)
+            typeInfo = this.resolveTypeSpec(expr.field.type, SearchType.FUNC)
             if(!typeInfo) {
                 // TODO: mark an error?
                 return false

--- a/src/lita.lita
+++ b/src/lita.lita
@@ -102,6 +102,7 @@ public enum PkgCommand {
     PKG_INSTALL,
     PKG_RUN,
     PKG_INIT,
+    PKG_BUILD,
 }
 
 public struct PkgOptions {

--- a/src/lita.lita
+++ b/src/lita.lita
@@ -101,12 +101,15 @@ public enum PkgCommand {
     PKG_NONE = 0,
     PKG_INSTALL,
     PKG_RUN,
+    PKG_INIT,
 }
 
 public struct PkgOptions {
     pkgCmd: PkgCommand             // the Package Manager command we're running (if any)
     pkgRunCmdArg: *const char      // the pkg-run {arg} argument
     forceClean: bool               // force cleaning of package directories
+
+    pkgName: *const char           // pkg-init options
 }
 
 public struct LitaOptions {

--- a/src/lita.lita
+++ b/src/lita.lita
@@ -140,6 +140,7 @@ public struct LitaOptions {
     testsOnly: bool                // if we are running tests only
     testsRegex: *const char        // the regex of tests to include
     testFileOnly: bool             // if we should only test the supplied file only
+    testPath: [MAX_PATH]char       // directory for tests
 
     typeOption: TypeInfoOption     // type generation option
 
@@ -329,7 +330,13 @@ public func (this: *Lita) parse() : *Module {
         return null;
     }
 
-    var packageName = GetPackageName(this.options.srcPath, this.options.inputFile)
+    var srcPath = this.options.testsOnly
+        ? this.options.testPath : this.options.srcPath;
+
+    var absolutePath = [MAX_PATH]char{0};
+    GetAbsolutePath(CurrentWorkingPath(), srcPath, absolutePath)
+
+    var packageName = GetPackageName(absolutePath, this.options.inputFile)
     var root = NewModule(this, packageName, this.options.inputFile)
     this.addModule(root)
 
@@ -679,6 +686,16 @@ public func FindModulePath(lita: *Lita,
         }
     }
 
+    // check to see if this is in the test path
+    {
+        if(lita.options.testsOnly) {
+            pathStr.format("%s/%.*s.lita", lita.options.testPath, moduleName.length, moduleName.buffer)
+            if(FileExists(pathStr.cStrConst())) {
+                return true
+            }
+        }
+    }
+
     pathStr.clear()
     return false
 }
@@ -767,17 +784,11 @@ func GetPackageName(srcPath: *const char, inputFile: *const char) : StringView {
         var inputFileView = StringViewInit(inputFile)
         var index = inputFileView.indexOf(srcPath)
         if(index > -1) {
-            inputFile = &inputFile[index + strlen(srcPath) + 1]
+            inputFile = &inputFile[index + strlen(srcPath)]
         }
     }
 
-    var endCount = 0
-    var startCount = 0
-
-    var inputLen = strlen(inputFile)
-
     while(*inputFile) {
-
         var c = *inputFile;
 
         if(c != '.' && c != '/' && c != '\\') {
@@ -785,9 +796,10 @@ func GetPackageName(srcPath: *const char, inputFile: *const char) : StringView {
         }
 
         inputFile  += 1
-        startCount += 1
     }
 
+    var inputLen = strlen(inputFile)
+    var endCount = 0
     for(var i = inputLen; i >= 0; i-=1) {
         var c = inputFile[i]
         if(c == '.') {
@@ -798,7 +810,7 @@ func GetPackageName(srcPath: *const char, inputFile: *const char) : StringView {
     }
 
     return StringView {
-        .length = inputLen - (endCount+startCount),
+        .length = inputLen - endCount,
         .buffer = inputFile,
     }
 }

--- a/src/main.lita
+++ b/src/main.lita
@@ -27,14 +27,11 @@ import "cgen"
 import "lsp"
 import "intern"
 import "build"
-
+import "config"
 import "pkg_mgr"
 
-import "config"
 
 func main(len: i32, args: **char) : i32 {
-    var startTime = SystemTimeMSec()
-
     var options = new<LitaOptions>()
     memset(options, 0, sizeof(:LitaOptions))
     defer defaultAllocator.free(options)
@@ -47,6 +44,12 @@ func main(len: i32, args: **char) : i32 {
     if(options.pkgOptions.pkgCmd != PkgCommand.PKG_NONE) {
         return HandlePkgCommand(options)
     }
+
+    return RunLitac(options)
+}
+
+public func RunLitac(options: *LitaOptions) : i32 {
+    var startTime = SystemTimeMSec()
 
     var lita = Lita{}
     lita.init(options)
@@ -122,20 +125,6 @@ report:
 
 
     if(runProgram) {
-        /*
-        var m = lita.getModule("src/main.lita")
-        lita.incrementalBuild(m)
-        lita.incrementalBuild(m)
-
-        if(!lita.result.errors.empty()) {
-            for(var i = 0; i < lita.result.errors.size(); i += 1) {
-                PrintError(sb, lita.result.errors.get(i))
-
-                printf("%s\n", sb.cStr())
-                sb.clear()
-            }
-            printf("Total errors: %d\n", lita.result.errors.size())
-        }*/
         return lita.run()
     }
 
@@ -148,7 +137,7 @@ enum ParseStatus {
     TERMINATE,
 }
 
-func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
+public func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     var parser = CmdParserInit()
     defer parser.free()
 
@@ -180,6 +169,7 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     parser.addOption("force",          '\0', "Forces a full clean install of all packages.  Must be ran with `pkg-install` option, otherwise will be ignored.", 0, null);
     parser.addOption("pkg-run",        '\0', "Runs a script defined in the `commands` section in this projects `pkg.json`.  The argument passed of this option is used to run the `commands.{option}` command", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("pkg-init",       '\0', "Initializes a new LitaC package project", OptionFlag.HAS_ARGUMENT, null);
+    parser.addOption("pkg-build",      '\0', "Builds the LitaC package", 0, null);
     parser.addOption("proxy",          '\0', "Defines a proxy server to use when making network calls.  Ex. -proxy https://proxy.com:443", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("buildCmd",       'b',  "The underlying C compiler build and compile command.  Variables will be substituted if found:\n%output%\tThe executable name\n%input%\tThe file(s) generated.\n%options%\tThe generated @compiler_option's if -strict option is enabled. \nOtherwise, the LitaC compiler will append any @compiler_option flags to this command.", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("strict",         '\0', "The LitaC compiler will not modify the `buildCmd` option (for applying @compiler_option), instead it will store the generated @compiler_options in the %options% substitution variable.", 0, null);
@@ -222,6 +212,10 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     if(parser.hasOption("pkg-init")) {
         options.pkgOptions.pkgCmd = PkgCommand.PKG_INIT
         options.pkgOptions.pkgName = parser.getOption("pkg-init").value
+    }
+
+    if(parser.hasOption("pkg-build")) {
+        options.pkgOptions.pkgCmd = PkgCommand.PKG_BUILD
     }
 
     options.languageServer = parser.hasOption("languageServer")
@@ -380,12 +374,10 @@ func HandlePkgCommand(options: *LitaOptions) : i32 {
     defer defaultAllocator.free(linearAllocator.mem)
 
     var pm = PackageManager{};
-    pm.init(PackageSyncOptions{
+    pm.init(PackageOptions{
         .projectPath = options.projectPath,
-        .fullSync = options.pkgOptions.forceClean,
-        .httpOptions = HttpOptions {
-            .proxy = options.proxy,
-        }
+        .litaOptions = options,
+
     }, linearAllocator.allocator)
     defer pm.free()
 
@@ -399,6 +391,9 @@ func HandlePkgCommand(options: *LitaOptions) : i32 {
         case PkgCommand.PKG_INIT: {
             return RunPkgInit(options, &pm)
         }
+        case PkgCommand.PKG_BUILD: {
+            return RunPkgBuild(options, &pm)
+        }
         default:
             return 0;
     }
@@ -407,7 +402,12 @@ func HandlePkgCommand(options: *LitaOptions) : i32 {
 }
 
 func RunPkgInstall(options: *LitaOptions, pm: *PackageManager) : i32 {
-    var status = pm.install()
+    var status = pm.installCommand(PackageInstallOptions {
+        .fullSync = options.pkgOptions.forceClean,
+        .httpOptions = HttpOptions {
+            .proxy = options.proxy,
+        }
+    })
     if(status != PkgStatus.OK) {
         printf("Error installing packages:\nErrorCode: %s - %s\n",
             PkgStatusAsStr(status), pm.errors.cStr())
@@ -458,6 +458,17 @@ func RunPkgInit(options: *LitaOptions, pm: *PackageManager) : i32 {
     })
     if(status != PkgStatus.OK) {
         printf("Error running pkg init:\nErrorCode: %s - %s\n",
+            PkgStatusAsStr(status), pm.errors.cStr())
+        return 1;
+    }
+    return 0;
+}
+
+func RunPkgBuild(options: *LitaOptions, pm: *PackageManager) : i32 {
+    var status = pm.buildCommand(PackageBuildOptions {
+    })
+    if(status != PkgStatus.OK) {
+        printf("Error running pkg build:\nErrorCode: %s - %s\n",
             PkgStatusAsStr(status), pm.errors.cStr())
         return 1;
     }

--- a/src/main.lita
+++ b/src/main.lita
@@ -165,6 +165,7 @@ public func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus
     parser.addOption("types",          't', "Includes TypeInfo for reflection\n<arg> can be:\nall       Means all types will have reflection values\ntagged    Means only basic types and types annotated with @typeinfo will have reflection values", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("test",           '\0', "Runs functions annotated with @test\n<arg> is a regex of which tests should be run", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("testFile",       '\0', "Runs functions annotated with @test in the suppplied source file only", 0, null);
+    parser.addOption("testDir",        '\0', "Specifies the source code test directory", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("pkg-install",    '\0', "Scans for a pkg.json file and downloads and installs LitaC packages defined in the `dependencies` section.\nIf successful, creates a build.json which is used for building this LitaC project.", 0, null);
     parser.addOption("force",          '\0', "Forces a full clean install of all packages.  Must be ran with `pkg-install` option, otherwise will be ignored.", 0, null);
     parser.addOption("pkg-run",        '\0', "Runs a script defined in the `commands` section in this projects `pkg.json`.  The argument passed of this option is used to run the `commands.{option}` command", OptionFlag.HAS_ARGUMENT, null);
@@ -332,6 +333,13 @@ public func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus
         else {
             FileParent(options.inputFile, options.srcPath)
         }
+    }
+
+    if(parser.hasOption("testDir")) {
+        StringCopy(.src = parser.getOption("testDir").value, .dest = options.testPath, .size = MAX_PATH)
+    }
+    else {
+        StringCopy(.src = "/test", .dest = options.testPath, .size = MAX_PATH)
     }
 
     // if there is no source path

--- a/src/main.lita
+++ b/src/main.lita
@@ -220,13 +220,23 @@ public func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus
     }
 
     options.languageServer = parser.hasOption("languageServer")
-    if(!options.languageServer && options.pkgOptions.pkgCmd == PkgCommand.PKG_NONE) {
-        if(parser.args.size() < 2) {
-            printf("Missing input file\n")
-            goto err;
-        }
+    if(!options.languageServer) {
 
-        GetAbsolutePath(CurrentWorkingPath(), parser.args.get(1), options.inputFile)
+        // if we are not running a pkg* command, we must have an input file
+        if(options.pkgOptions.pkgCmd == PkgCommand.PKG_NONE) {
+            if(parser.args.size() < 2) {
+                printf("Missing input file\n")
+                goto err;
+            }
+
+            GetAbsolutePath(CurrentWorkingPath(), parser.args.get(1), options.inputFile)
+        }
+        else {
+            // we optionally can provide an input file for pkg* commands
+            if(parser.args.size() > 1) {
+                GetAbsolutePath(CurrentWorkingPath(), parser.args.get(1), options.inputFile)
+            }
+        }
     }
 
     var lib:*const char = GetEnv("LITAC_HOME")

--- a/src/main.lita
+++ b/src/main.lita
@@ -179,6 +179,7 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     parser.addOption("pkg-install",    '\0', "Scans for a pkg.json file and downloads and installs LitaC packages defined in the `dependencies` section.\nIf successful, creates a build.json which is used for building this LitaC project.", 0, null);
     parser.addOption("force",          '\0', "Forces a full clean install of all packages.  Must be ran with `pkg-install` option, otherwise will be ignored.", 0, null);
     parser.addOption("pkg-run",        '\0', "Runs a script defined in the `commands` section in this projects `pkg.json`.  The argument passed of this option is used to run the `commands.{option}` command", OptionFlag.HAS_ARGUMENT, null);
+    parser.addOption("pkg-init",       '\0', "Initializes a new LitaC package project", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("proxy",          '\0', "Defines a proxy server to use when making network calls.  Ex. -proxy https://proxy.com:443", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("buildCmd",       'b',  "The underlying C compiler build and compile command.  Variables will be substituted if found:\n%output%\tThe executable name\n%input%\tThe file(s) generated.\n%options%\tThe generated @compiler_option's if -strict option is enabled. \nOtherwise, the LitaC compiler will append any @compiler_option flags to this command.", OptionFlag.HAS_ARGUMENT, null);
     parser.addOption("strict",         '\0', "The LitaC compiler will not modify the `buildCmd` option (for applying @compiler_option), instead it will store the generated @compiler_options in the %options% substitution variable.", 0, null);
@@ -216,6 +217,11 @@ func ParseArgs(n: i32, args: **char, options: *LitaOptions) : ParseStatus {
     if(parser.hasOption("pkg-run")) {
         options.pkgOptions.pkgCmd = PkgCommand.PKG_RUN
         options.pkgOptions.pkgRunCmdArg = parser.getOption("pkg-run").value
+    }
+
+    if(parser.hasOption("pkg-init")) {
+        options.pkgOptions.pkgCmd = PkgCommand.PKG_INIT
+        options.pkgOptions.pkgName = parser.getOption("pkg-init").value
     }
 
     options.languageServer = parser.hasOption("languageServer")
@@ -390,6 +396,9 @@ func HandlePkgCommand(options: *LitaOptions) : i32 {
         case PkgCommand.PKG_RUN: {
             return RunPkgCommand(options, &pm)
         }
+        case PkgCommand.PKG_INIT: {
+            return RunPkgInit(options, &pm)
+        }
         default:
             return 0;
     }
@@ -436,6 +445,19 @@ func RunPkgCommand(options: *LitaOptions, pm: *PackageManager) : i32 {
     var status = pm.runCommand(options.pkgOptions.pkgRunCmdArg)
     if(status != PkgStatus.OK) {
         printf("Error running pkg command:\nErrorCode: %s - %s\n",
+            PkgStatusAsStr(status), pm.errors.cStr())
+        return 1;
+    }
+    return 0;
+}
+
+
+func RunPkgInit(options: *LitaOptions, pm: *PackageManager) : i32 {
+    var status = pm.initCommand(PackageInitOptions {
+        .name = options.pkgOptions.pkgName
+    })
+    if(status != PkgStatus.OK) {
+        printf("Error running pkg init:\nErrorCode: %s - %s\n",
             PkgStatusAsStr(status), pm.errors.cStr())
         return 1;
     }

--- a/src/module.lita
+++ b/src/module.lita
@@ -204,6 +204,15 @@ public func (this: *Module) getFuncType(type: InternedString) : *Symbol {
     return this.genericSymbols.get(type) // TODO: Separate out Func in generic symbols
 }
 
+public func (this: *Module) getNoteType(type: InternedString) : *Symbol {
+    var sym = this.symbols.lookupNote(type)
+    if(sym) {
+        return sym
+    }
+
+    return this.genericSymbols.get(type)
+}
+
 public const MAX_METHODS_FOR_TYPE = 2048; // TODO: this should be big enough??
 
 func (this: *Module) isMethodForType(type: *TypeInfo, sym: *Symbol) : bool {

--- a/src/pkg_mgr/pkg_build.lita
+++ b/src/pkg_mgr/pkg_build.lita
@@ -131,7 +131,11 @@ func (this: *PackageManager) buildCommandArgs(
     programArgs.add("-output")
     programArgs.add(this.pkg.json.getStr("name", "a"))
 
-    programArgs.add("./src/main.lita")
+    programArgs.add("-srcDir")
+    programArgs.add("./src/")
+
+    var mainFile = "./src/main.lita"
+
 
     // TEMP: should move into specific commands?
     {
@@ -140,10 +144,16 @@ func (this: *PackageManager) buildCommandArgs(
         }
 
         if(this.options.litaOptions.testsOnly && this.options.litaOptions.testsRegex) {
+            programArgs.add("-testDir")
+            programArgs.add("./test/")
+
             programArgs.add("-test")
             programArgs.add(this.options.litaOptions.testsRegex)
+            mainFile = "./test/main_test.lita"
         }
     }
+
+    programArgs.add(mainFile)
 
     args.n = programArgs.size()
     args.args = programArgs.elements as (**char)

--- a/src/pkg_mgr/pkg_build.lita
+++ b/src/pkg_mgr/pkg_build.lita
@@ -153,6 +153,10 @@ func (this: *PackageManager) buildCommandArgs(
         }
     }
 
+    if(strlen(this.options.litaOptions.inputFile) > 0) {
+        mainFile = this.options.litaOptions.inputFile as (*const char)
+    }
+
     programArgs.add(mainFile)
 
     args.n = programArgs.size()

--- a/src/pkg_mgr/pkg_build.lita
+++ b/src/pkg_mgr/pkg_build.lita
@@ -1,0 +1,229 @@
+import "pkg_mgr"
+import "std/system" as sys
+import "std/mem"
+import "std/string"
+import "std/string_buffer"
+import "std/array"
+import "std/json"
+import "std/libc"
+import "std/io"
+import "std/cmdline"
+
+import "main"
+import "lita"
+
+struct CommandArgs {
+    n: i32
+    args: **char
+}
+
+public func PackageBuild(pm: *PackageManager, options: PackageBuildOptions) : PkgStatus {
+    if(!pm.pkg) {
+        return PkgStatus.ERROR_NO_PROJECT_PKG_FOUND
+    }
+
+    if(!pm.pkg.json) {
+        return PkgStatus.ERROR_PARSING_PKG_JSON
+    }
+
+    var buildCommand = pm.pkg.json.get("build_command")
+    if(!buildCommand) {
+        return PkgStatus.ERROR_COMMAND_NOT_DEFINED
+    }
+
+    var litaOptions = new<LitaOptions>()
+    memset(litaOptions, 0, sizeof(:LitaOptions))
+    defer defaultAllocator.free(litaOptions)
+
+    var args = CommandArgs{}
+    var result = pm.buildCommandArgs(buildCommand, options, &args)
+    if(result != PkgStatus.OK) {
+        return result
+    }
+
+    if(ParseArgs(args.n, args.args, litaOptions) != CmdParserStatus.OK) {
+        return PkgStatus.ERROR_PARSING_BUILD_OPTIONS
+    }
+
+    // printf("Options: \n")
+    // for(var i = 0; i < args.n; i+=1) {
+    //     printf("%s\n", args.args[i])
+    // }
+
+    RunLitac(litaOptions)
+    return PkgStatus.OK
+}
+
+func (this: *PackageManager) buildCommandArgs(
+    buildCommand: *JsonNode,
+    options: PackageBuildOptions,
+    args: *CommandArgs) : PkgStatus {
+
+    var buildSection: *JsonNode = null
+
+    var defaultTarget = buildCommand.get("default")
+    var target: *JsonNode = GetTarget(buildCommand, defaultTarget, options)
+    if(target) {
+        var defaultOS = target.get("default")
+        var os: *JsonNode = GetOS(target, defaultTarget)
+        if(os) {
+            var arch: *JsonNode = GetArch(os, defaultOS)
+            buildSection = arch
+        }
+    }
+
+    var programArgs = ArrayInit<*const char>(64, this.allocator)
+    programArgs.add("litac")
+
+    if(buildSection) {
+        var script = buildSection.get("script")
+        if(script) {
+            return this.buildWithScript(script)
+        }
+
+        var buildCmd = StringBufferInit(1024)
+        var cc = buildSection.getStr("cc", "clang")
+        var ccOptions = buildSection.get("cc_options")
+        if(ccOptions) {
+            buildCmd.append("%s ", cc)
+            if(ccOptions.isString()) {
+                buildCmd.append("%s", ccOptions.asString())
+            }
+            else if(ccOptions.isArray()) {
+                var isFirst = true
+                for(var i = 0; i < ccOptions.size(); i+=1) {
+                    if(!isFirst) {
+                        buildCmd.appendStrn(" ", 1)
+                    }
+
+                    isFirst = false
+
+                    var n = ccOptions.at(i)
+                    buildCmd.append("%s", n.asString())
+                }
+            }
+        }
+
+
+        var litaOptions = buildSection.get("lita_options")
+        if(litaOptions) {
+           buildCmd.append("%s ", cc)
+            if(litaOptions.isString()) {
+                programArgs.add(litaOptions.asString())
+            }
+            else if(litaOptions.isArray()) {
+                for(var i = 0; i < litaOptions.size(); i+=1) {
+                    var n = litaOptions.at(i)
+                    programArgs.add(n.asString())
+                }
+            }
+        }
+
+        if(!buildCmd.empty()) {
+            programArgs.add("-buildCmd")
+            programArgs.add(buildCmd.cStr())
+        }
+    }
+
+    programArgs.add("-outputDir")
+    programArgs.add("./bin/")
+
+    programArgs.add("-output")
+    programArgs.add(this.pkg.json.getStr("name", "a"))
+
+    programArgs.add("./src/main.lita")
+
+    // TEMP: should move into specific commands?
+    {
+        if(this.options.litaOptions.run) {
+            programArgs.add("-run")
+        }
+
+        if(this.options.litaOptions.testsOnly && this.options.litaOptions.testsRegex) {
+            programArgs.add("-test")
+            programArgs.add(this.options.litaOptions.testsRegex)
+        }
+    }
+
+    args.n = programArgs.size()
+    args.args = programArgs.elements as (**char)
+
+    return PkgStatus.OK
+}
+
+
+func (this: *PackageManager) buildWithScript(script: *JsonNode) : PkgStatus {
+    // TODO: Implement running script..
+    printf("'script' is not implemented yet...")
+    return PkgStatus.OK
+}
+
+func GetTarget(buildCommand: *JsonNode, defaultTarget: *JsonNode, options: PackageBuildOptions) : *JsonNode {
+    var target: *JsonNode = null
+    if(options.isRelease) {
+        target = buildCommand.get("release")
+    }
+    else {
+        target = buildCommand.get("debug")
+    }
+
+    if(!target) {
+        target = defaultTarget
+    }
+
+    return target
+}
+
+func GetOS(target: *JsonNode, defaultTarget: *JsonNode) : *JsonNode {
+    var os: *JsonNode = null
+    var defaultOS = target.get("default")
+
+#static_if defined(_WIN32) || defined(_WIN64)
+    os = target.get("windows")
+#elseif defined(__linux__)
+    os = target.get("linux")
+#elseif defined(__APPLE__) && defined(__MACH__)
+    os = target.get("mac")
+#end
+
+    if(!os) {
+        os = defaultOS
+    }
+
+    // Try to use the default
+    if(!os) {
+        if(!os && defaultTarget) {
+            os = GetOS(defaultTarget, null)
+        }
+    }
+
+    return os
+}
+
+func GetArch(os: *JsonNode, defaultOS: *JsonNode) : *JsonNode {
+    var arch: *JsonNode = null
+    var defaultArch = os.get("default")
+
+#static_if defined(LITA_X86)
+    arch = os.get("x86")
+#elseif defined(LITA_X64)
+    arch = os.get("x64")
+#elseif defined(LITA_ARM32)
+    arch = os.get("arm32")
+#elseif defined(LITA_ARM64)
+    arch = os.get("arm64")
+#end
+
+    if(!arch) {
+        arch = defaultArch
+    }
+
+    // Try to use the default
+    if(!arch) {
+        if(defaultOS) {
+            arch = GetArch(defaultOS, null)
+        }
+    }
+
+    return arch
+}

--- a/src/pkg_mgr/pkg_build.lita
+++ b/src/pkg_mgr/pkg_build.lita
@@ -140,12 +140,18 @@ func (this: *PackageManager) buildCommandArgs(
             programArgs.add("-run")
         }
 
-        if(this.options.litaOptions.testsOnly && this.options.litaOptions.testsRegex) {
+        if(this.options.litaOptions.testsOnly) {
             programArgs.add("-testDir")
             programArgs.add("./test/")
 
-            programArgs.add("-test")
-            programArgs.add(this.options.litaOptions.testsRegex)
+            if(this.options.litaOptions.testsRegex) {
+                programArgs.add("-test")
+                programArgs.add(this.options.litaOptions.testsRegex)
+            }
+            else {
+                programArgs.add("-testFile")
+            }
+
             mainFile = "./test/main_test.lita"
         }
     }

--- a/src/pkg_mgr/pkg_build.lita
+++ b/src/pkg_mgr/pkg_build.lita
@@ -45,10 +45,7 @@ public func PackageBuild(pm: *PackageManager, options: PackageBuildOptions) : Pk
         return PkgStatus.ERROR_PARSING_BUILD_OPTIONS
     }
 
-    // printf("Options: \n")
-    // for(var i = 0; i < args.n; i+=1) {
-    //     printf("%s\n", args.args[i])
-    // }
+    // TODO: Recursively build dependencies too...
 
     RunLitac(litaOptions)
     return PkgStatus.OK

--- a/src/pkg_mgr/pkg_init.lita
+++ b/src/pkg_mgr/pkg_init.lita
@@ -1,0 +1,103 @@
+import "pkg_mgr"
+import "std/system"
+import "std/string"
+import "std/string_buffer"
+import "std/array"
+import "std/json"
+import "std/libc"
+import "std/io"
+
+
+public func PackageInit(pm: *PackageManager, options: PackageInitOptions) : PkgStatus {
+    const MAX_BUFFER = 1024
+    var buffer = [MAX_BUFFER]char{};
+    var path = StringInit(buffer, MAX_BUFFER, 0)
+
+    path.format("%s/bin", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/doc", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/lib", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/src", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+    path.format("%s/test", pm.options.projectPath)
+    Mkdir(path.cStr())
+
+
+    var sb = StringBufferInit(1024)
+    defer sb.free()
+
+    // Write out main.lita
+    {
+        sb.append("%s",
+"""
+import "std/libc"
+
+func main(len: i32, args: **char) : i32 {
+    printf("Hello World")
+}
+""")
+
+        path.format("%s/src/main.lita", pm.options.projectPath)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
+    }
+
+    // Write out main_test.lita
+    {
+        sb.clear().append("%s",
+"""
+import "main"
+
+@test("project_test")
+func test() {
+    assert(true)
+}
+
+""")
+
+        path.format("%s/test/main_test.lita", pm.options.projectPath)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
+    }
+
+    // Write out pkg.json
+    {
+        sb.clear().append("""
+{
+    "name" : "%s",
+    "version" : "%s",
+    "type" : "%s",
+    "repo" : "%s",
+
+    "build_command" : {
+        "default" : {
+            "default" : {
+                "cc" : "clang",
+                "cc_options" : "-std=c99 -fsanitize=undefined,address %%input%% -o %%output%% -D_CRT_SECURE_NO_WARNINGS",
+                "lita_options" : ""
+            }
+        }
+    },
+
+    "dependencies": [],
+
+}
+""" // TODO: Json escape strings...
+        , options.name, options.version, options.type, options.repo)
+
+        path.format("%s/pkg.json", pm.options.projectPath)
+        if(WriteFile(path.cStr(), sb.buffer, sb.length) != FileStatus.Ok) {
+            return PkgStatus.ERROR_INIT_PACKAGE
+        }
+    }
+
+    return PkgStatus.OK
+}

--- a/src/pkg_mgr/pkg_init.lita
+++ b/src/pkg_mgr/pkg_init.lita
@@ -40,6 +40,7 @@ import "std/libc"
 
 func main(len: i32, args: **char) : i32 {
     printf("Hello World")
+    return 0
 }
 """)
 

--- a/src/pkg_mgr/pkg_install.lita
+++ b/src/pkg_mgr/pkg_install.lita
@@ -23,15 +23,13 @@ import "std/thread/thread_pool"
 
 const INSTALL_COMPLETED_FILE = ".litac_pkg"
 
-public func PackageSync(pm: *PackageManager) : PkgStatus {
+public func PackageInstall(pm: *PackageManager, options: PackageInstallOptions) : PkgStatus {
     if(!pm.pkg) {
         return PkgStatus.OK
     }
 
-    var options = pm.options
-
-    Mkdir(options.pkgDir)
-    if(!FileExists(options.pkgDir)) {
+    Mkdir(pm.options.pkgDir)
+    if(!FileExists(pm.options.pkgDir)) {
         return PkgStatus.ERROR_CREATING_PKG_DIR
     }
 
@@ -40,10 +38,10 @@ public func PackageSync(pm: *PackageManager) : PkgStatus {
         return PkgStatus.OK
     }
 
-    if(pm.options.fullSync) {
+    if(options.fullSync) {
         var temp:[MAX_PATH]char;
         var pkgPath = StringInit(temp, MAX_PATH, 0)
-        pkgPath.format("%s/%s", CurrentWorkingPath(), options.pkgDir)
+        pkgPath.format("%s/%s", CurrentWorkingPath(), pm.options.pkgDir)
 
         var status = cleanPackageDirectory(pm, pkgPath.cStr())
         if(status != PkgStatus.OK) {
@@ -60,7 +58,7 @@ public func PackageSync(pm: *PackageManager) : PkgStatus {
     }
 
     var http = Http{}
-    http.init(pm.options.httpOptions)
+    http.init(options.httpOptions)
     defer http.free()
 
     var pkgPath:[MAX_PATH]char;

--- a/src/pkg_mgr/pkg_mgr.lita
+++ b/src/pkg_mgr/pkg_mgr.lita
@@ -102,6 +102,7 @@ import "std/string_view"
 import "pkg_mgr/pkg"
 import "pkg_mgr/pkg_install"
 import "pkg_mgr/pkg_run"
+import "pkg_mgr/pkg_init"
 
 import "build"
 
@@ -110,6 +111,14 @@ public struct PackageSyncOptions {
     pkgDir: *const char = ".pkgs"       // the .pkgs directory
     fullSync: bool = false              // force a full download of all packages
     httpOptions: HttpOptions            // http options
+}
+
+
+public struct PackageInitOptions {
+    name: *const char
+    version: *const char = "0.0.1"
+    type: *const char = "executable"
+    repo: *const char = ""
 }
 
 @asStr
@@ -133,6 +142,7 @@ public enum PkgStatus {
     ERROR_HTTP_STATUS,
     ERROR_INVALID_DIRECTORY,
     ERROR_INVALID_REPO,
+    ERROR_INIT_PACKAGE,
 }
 
 public struct PackageManager {
@@ -182,6 +192,14 @@ func (this: *PackageManager) printMessages() {
     if(this.errors.length > 0) {
         printf("Error: %s\n", this.errors.cStr())
     }
+}
+
+@doc("""
+    Initializes a new LitaC project, writing out scaffolding files
+""")
+public func (this: *PackageManager) initCommand(options: PackageInitOptions) : PkgStatus {
+    defer this.printMessages()
+    return PackageInit(this, options)
 }
 
 @doc("""

--- a/src/pkg_mgr/pkg_mgr.lita
+++ b/src/pkg_mgr/pkg_mgr.lita
@@ -104,7 +104,6 @@ import "pkg_mgr/pkg_install"
 import "pkg_mgr/pkg_build"
 import "pkg_mgr/pkg_run"
 import "pkg_mgr/pkg_init"
-import "pkg_mgr/pkg_init"
 
 import "build"
 import "lita"
@@ -132,13 +131,6 @@ public struct PackageInstallOptions {
     httpOptions: HttpOptions            // http options
 }
 
-
-public struct PackageInitOptions {
-    name: *const char
-    version: *const char = "0.0.1"
-    type: *const char = "executable"
-    repo: *const char = ""
-}
 
 @asStr
 public enum PkgStatus {

--- a/src/pkg_mgr/pkg_mgr.lita
+++ b/src/pkg_mgr/pkg_mgr.lita
@@ -101,16 +101,17 @@ import "std/string_view"
 
 import "pkg_mgr/pkg"
 import "pkg_mgr/pkg_install"
+import "pkg_mgr/pkg_build"
 import "pkg_mgr/pkg_run"
 import "pkg_mgr/pkg_init"
 
 import "build"
+import "lita"
 
-public struct PackageSyncOptions {
+public struct PackageOptions {
     projectPath: *const char
     pkgDir: *const char = ".pkgs"       // the .pkgs directory
-    fullSync: bool = false              // force a full download of all packages
-    httpOptions: HttpOptions            // http options
+    litaOptions: *LitaOptions
 }
 
 
@@ -119,6 +120,15 @@ public struct PackageInitOptions {
     version: *const char = "0.0.1"
     type: *const char = "executable"
     repo: *const char = ""
+}
+
+public struct PackageBuildOptions {
+    isRelease: bool = false
+}
+
+public struct PackageInstallOptions {
+    fullSync: bool = false              // force a full download of all packages
+    httpOptions: HttpOptions            // http options
 }
 
 @asStr
@@ -143,10 +153,14 @@ public enum PkgStatus {
     ERROR_INVALID_DIRECTORY,
     ERROR_INVALID_REPO,
     ERROR_INIT_PACKAGE,
+    ERROR_PARSING_BUILD_OPTIONS,
+    ERROR_INVALID_BUILD_TARGET,
+    ERROR_INVALID_BUILD_OS,
+    ERROR_INVALID_BUILD_ARCH,
 }
 
 public struct PackageManager {
-    options: PackageSyncOptions
+    options: PackageOptions
     allocator: *const Allocator
 
     packages: Map<*const char, *PackageDef>
@@ -157,7 +171,7 @@ public struct PackageManager {
 }
 
 public func (this: *PackageManager) init(
-    options: PackageSyncOptions,
+    options: PackageOptions,
     allocator: *const Allocator = defaultAllocator) {
 
     this.options = options
@@ -203,9 +217,23 @@ public func (this: *PackageManager) initCommand(options: PackageInitOptions) : P
 }
 
 @doc("""
+    Initializes a new LitaC project, writing out scaffolding files
+""")
+public func (this: *PackageManager) buildCommand(options: PackageBuildOptions) : PkgStatus {
+    defer this.printMessages()
+
+    var status = this.readProjectPkg()
+    if(status != PkgStatus.OK) {
+        return status;
+    }
+
+    return PackageBuild(this, options)
+}
+
+@doc("""
     Installs all packages defined the pkg.json to the file system.
 """)
-public func (this: *PackageManager) install() : PkgStatus {
+public func (this: *PackageManager) installCommand(options: PackageInstallOptions) : PkgStatus {
     defer this.printMessages()
 
     var status = this.readProjectPkg()
@@ -223,7 +251,7 @@ public func (this: *PackageManager) install() : PkgStatus {
         }
     }
 
-    return PackageSync(this)
+    return PackageInstall(this, options)
 }
 
 @doc("""

--- a/src/preprocessor/api.lita
+++ b/src/preprocessor/api.lita
@@ -896,9 +896,16 @@ func ApeGetSymbolsToTest(ape: *ape_t, data: *void, argc: i32, args: *ape_object_
         var all = strcmp(context.pp.lita.options.testsRegex, ".*") == 0
         var pattern = RegexCompile(context.pp.lita.options.testsRegex)
 
+        var testModule = context.checker.current
+
         for(var i = 0; i < context.checker.symbolFuncs.size(); i += 1) {
             var sym = context.checker.symbolFuncs.get(i)
-            if(sym.kind == SymbolKind.FUNC && sym.decl.hasNote("test")) {
+            if(sym.kind == SymbolKind.FUNC && sym.flags & SymbolFlags.IS_TEST) {
+
+                if(!sym.isVisibleTo(testModule)) {
+                    continue;
+                }
+
                 if(all) {
                     var declObj = context.pp.declToApe(sym)
                     ape_object_add_array_value(results, declObj)
@@ -948,7 +955,7 @@ func ApeGetSymbolsToTest(ape: *ape_t, data: *void, argc: i32, args: *ape_object_
         // iterate thru all symbols, this way we are deterministic in our output
         for(var i = 0; i < context.checker.symbolFuncs.size(); i += 1) {
             var sym = context.checker.symbolFuncs.get(i)
-            if(sym.declared == mainModule && sym.kind == SymbolKind.FUNC && sym.decl.hasNote("test")) {
+            if(sym.declared == mainModule && sym.kind == SymbolKind.FUNC && sym.flags & SymbolFlags.IS_TEST) {
                 var declObj = context.pp.declToApe(sym)
                 ape_object_add_array_value(results, declObj)
             }

--- a/src/preprocessor/api.lita
+++ b/src/preprocessor/api.lita
@@ -891,18 +891,22 @@ func ApeGetSymbolsToTest(ape: *ape_t, data: *void, argc: i32, args: *ape_object_
         return results
     }
 
+    var moduleName = context.pp.lita.options.inputFile
+    var mainModule = context.pp.lita.getModule(moduleName)
+    if(!mainModule) {
+        return results;
+    }
+
     // if we are testing by regex, test each function with @test attribute
     if(context.pp.lita.options.testsRegex) {
         var all = strcmp(context.pp.lita.options.testsRegex, ".*") == 0
         var pattern = RegexCompile(context.pp.lita.options.testsRegex)
 
-        var testModule = context.checker.current
-
         for(var i = 0; i < context.checker.symbolFuncs.size(); i += 1) {
             var sym = context.checker.symbolFuncs.get(i)
             if(sym.kind == SymbolKind.FUNC && sym.flags & SymbolFlags.IS_TEST) {
 
-                if(!sym.isVisibleTo(testModule)) {
+                if(!sym.isVisibleTo(mainModule)) {
                     continue;
                 }
 
@@ -946,12 +950,6 @@ func ApeGetSymbolsToTest(ape: *ape_t, data: *void, argc: i32, args: *ape_object_
     }
     // otherwise we are just testing the input file's tests
     else {
-        var moduleName = context.pp.lita.options.inputFile
-        var mainModule = context.pp.lita.getModule(moduleName)
-        if(!mainModule) {
-            return results;
-        }
-
         // iterate thru all symbols, this way we are deterministic in our output
         for(var i = 0; i < context.checker.symbolFuncs.size(); i += 1) {
             var sym = context.checker.symbolFuncs.get(i)

--- a/src/preprocessor/api.lita
+++ b/src/preprocessor/api.lita
@@ -60,6 +60,7 @@ public func (this: *Preprocessor) registerApi() {
     ape_set_native_function(this.runtime.ape, "addDeclaration", ApeAddDeclaration, &this.callContext)
     ape_set_native_function(this.runtime.ape, "replaceDeclaration", ApeReplaceDeclaration, &this.callContext)
     ape_set_native_function(this.runtime.ape, "addImport", ApeAddImport, &this.callContext)
+    ape_set_native_function(this.runtime.ape, "flushDeclarations", ApeFlushDeclarations, &this.callContext)
 
     ape_set_native_function(this.runtime.ape, "assert", ApeAssert, &this.callContext)
     ape_set_native_function(this.runtime.ape, "getMainSymbol", ApeGetMainSymbol, &this.callContext)
@@ -738,6 +739,12 @@ func ApeGetCurrentModuleFilename(ape: *ape_t, data: *void, argc: i32, args: *ape
     return ape_object_make_string(ape, moduleFilename)
 }
 
+
+func ApeFlushDeclarations(ape: *ape_t, data: *void, argc: i32, args: *ape_object_t) : ape_object_t {
+    var context = data as (*CallContext)
+    context.pp.drainQueue()
+    return ape_object_make_null()
+}
 
 func ApeGetMainSymbol(ape: *ape_t, data: *void, argc: i32, args: *ape_object_t) : ape_object_t {
     var context = data as (*CallContext)

--- a/src/preprocessor/preprocessor.lita
+++ b/src/preprocessor/preprocessor.lita
@@ -308,7 +308,7 @@ public func (this: *Preprocessor) postResolveSymbols(checker: *TypeChecker, isIn
 }
 
 
-func (this: *Preprocessor) drainQueue() {
+public func (this: *Preprocessor) drainQueue() {
     while(!this.declQueue.empty()) {
         var scriptDecl = this.declQueue.pop()
 

--- a/src/symbols.lita
+++ b/src/symbols.lita
@@ -106,6 +106,7 @@ public struct Scope {
     allocator: *const Allocator
     result: *PhaseResult
     parent: *Scope
+    symbolNotes: Map<InternedString, *Symbol>
     symbolTypes: Map<InternedString, *Symbol>
     symbolFuncs: Map<InternedString, *Symbol>
 
@@ -135,7 +136,17 @@ public func (scope: *Scope) init(kind: ScopeKind,
     scope.result = result
     scope.module = module
     scope.symbolTypes = InternMap<*Symbol>(null, 16, allocator)
-    scope.symbolFuncs = InternMap<*Symbol>(null, 16, allocator)
+
+    // we can only declare notes and functions at the module
+    // level
+    if(kind == ScopeKind.MODULE) {
+        scope.symbolFuncs = InternMap<*Symbol>(null, 16, allocator)
+        scope.symbolNotes = InternMap<*Symbol>(null, 16, allocator)
+    }
+    else {
+        scope.symbolFuncs = Map<InternedString, *Symbol>{}
+        scope.symbolNotes = Map<InternedString, *Symbol>{}
+    }
 }
 
 public func (scope: *Scope) initIncrementalBuild() {
@@ -159,6 +170,19 @@ public func (s: *Scope) lookupFunc(name: InternedString) : *Symbol {
     }
 
     return s.parent.lookupFunc(name)
+}
+
+public func (s: *Scope) lookupNote(name: InternedString) : *Symbol {
+    var sym = s.symbolNotes.get(name)
+    if(sym && !(sym.flags & SymbolFlags.IS_MARKED_RESET)) {
+        return sym
+    }
+
+    if(!s.parent) {
+        return null
+    }
+
+    return s.parent.lookupNote(name)
 }
 
 public func (s: *Scope) lookup(name: InternedString, includeFuncs: bool = true) : *Symbol {
@@ -204,9 +228,12 @@ public func (this: *Scope) importSymbol(importSrcPos: SrcPos,
                                         name: InternedString,
                                         symbol: *Symbol) {
 
-    var symbolStorage = &this.symbolFuncs;
-    if(symbol.kind != SymbolKind.FUNC) {
-        symbolStorage = &this.symbolTypes
+    var symbolStorage = &this.symbolTypes;
+    if(symbol.kind == SymbolKind.FUNC) {
+        symbolStorage = &this.symbolFuncs
+    }
+    else if(symbol.flags & SymbolFlags.IS_NOTE) {
+        symbolStorage = &this.symbolNotes
     }
 
     if(symbolStorage.contains(name) && !symbol.decl.hasNote("generated")) {
@@ -231,10 +258,12 @@ public func (this: *Scope) importSymbol(importSrcPos: SrcPos,
 }
 
 public func (this: *Scope) removeSymbol(symbol: *Symbol) {
-    var symbolStorage = &this.symbolFuncs
-
-    if(symbol.kind != SymbolKind.FUNC) {
-        symbolStorage = &this.symbolTypes
+    var symbolStorage = &this.symbolTypes;
+    if(symbol.kind == SymbolKind.FUNC) {
+        symbolStorage = &this.symbolFuncs
+    }
+    else if(symbol.flags & SymbolFlags.IS_NOTE) {
+        symbolStorage = &this.symbolNotes
     }
 
     // TODO: Performance!
@@ -260,9 +289,14 @@ public func (this: *Scope) addSymbol(name: InternedString,
 
     var symbolStorage = &this.symbolTypes
 
-    var isFunc = decl.kind == StmtKind.FUNC_DECL
-    if(isFunc) {
-        symbolStorage = &this.symbolFuncs
+    switch(decl.kind) {
+        case StmtKind.FUNC_DECL:
+            symbolStorage = &this.symbolFuncs
+            break;
+        case StmtKind.NOTE_DECL:
+            symbolStorage = &this.symbolNotes
+            break;
+        default: // do nothing
     }
 
     var sym: *Symbol = null;

--- a/src/symbols.lita
+++ b/src/symbols.lita
@@ -87,6 +87,22 @@ public func (this: *Symbol) isGenericCapable() : bool {
            this.flags & SymbolFlags.IS_FROM_GENERIC_TEMPLATE
 }
 
+public func (this: *Symbol) isVisibleTo(module: *Module) : bool {
+    if(this.declared == module) {
+        return true
+    }
+
+    if(this.flags & SymbolFlags.IS_PRIVATE) {
+        return false
+    }
+
+    if(this.flags & SymbolFlags.IS_PUBLIC) {
+        return true
+    }
+
+    return this.declared.isInPackage(module)
+}
+
 public enum ScopeKind {
     MODULE,
     FUNC,

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -203,7 +203,7 @@ public @note packed {
         emit("  return 0; }")
 
         addDeclaration(moduleName, emitStr())
-        // flushDeclarations()
+        flushDeclarations()
 
         setMainSymbol(moduleName, testFunctionName)
 

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -203,6 +203,8 @@ public @note packed {
         emit("  return 0; }")
 
         addDeclaration(moduleName, emitStr())
+        // flushDeclarations()
+
         setMainSymbol(moduleName, testFunctionName)
 
     }

--- a/stdlib/std/string_buffer.lita
+++ b/stdlib/std/string_buffer.lita
@@ -337,8 +337,9 @@ public func (b: *StringBuffer) size() : i32 {
 }
 
 @inline
-public func (b: *StringBuffer) clear() {
+public func (b: *StringBuffer) clear() : *StringBuffer {
     b.length = 0
+    return b
 }
 
 public func (b: *StringBuffer) cStrConst() : *const char {


### PR DESCRIPTION
Introduces the `pkg-build` command.  This will look for a `build_command` in the `pkg.json` file.  The expected structure of the `build_command` is:

```
    // Specify how to build the project and will recursively build all
    // dependent projects
    "build_command": {
        // For debug mode, "default" can be set as well
        "debug": {
            // Specify custom command for OS
            "windows" : {
                // Specify which CPU architecture
                "x86": {
                    // [Optional] Specify the C compiler to use
                    "cc": "clang", 
                     // [Optional] Specify C compiler options"
                    "cc_options": "-std=c99 -g -gcodeview -fsanitize=undefined,address %input% -o %output%  -D_CRT_SECURE_NO_WARNINGS",

                    // [Optional] Specify the litac command line options.  Default will include -buildCmd, -outputDir, -output and input file
                    "lita_options": ["-cFormat", "-profile", "-maxMemory", "1GiB"],

                    // If "script" is specified, will ignore the build_cmd and lita_options and run the supplied script
                    // "script" : "build.bat",
                }
            },
            "linux" : {
                // etc..
            }
        },
        "release": {
            // default will be used if no explicit OS is present
            "default" : {
                // default will be used if no explicit CPU arch is present
                "default" : {
                    "cc": "clang", 
                    "cc_options": "-std=c99 %input% -o %output%  -D_CRT_SECURE_NO_WARNINGS",
                    "lita_options": ["-maxMemory", "1GiB"]
                }
            }
        }
    },
```

To run, `litac -pkg-build` which will build your package.  

If you want to build and run: `litac -pkg-build -run`
If you want to build and test: `litac -pkg-build -run -test .*` which will default to look at the `test/main_test.lita` file for tests.  
If you want to test a specific file: `litac -pkg-build -run -testFile ./src/your_file.lita`.

Limitations
==
* Currently will only build the main package and not recursively build `dependencies` - shouldn't be too hard to implement, but wanted to get this PR out
* `script` option is not implemented yet

Fix for #37 