### PR TITLE
Added Native Strings

### DIFF
--- a/src/ast.lita
+++ b/src/ast.lita
@@ -75,6 +75,7 @@ public enum StmtKind {
     SET_EXPR,
     SIZE_OF_EXPR,
     STRING_EXPR,
+    NATIVE_STRING_EXPR,
     SUBSCRIPT_GET_EXPR,
     SUBSCRIPT_SET_EXPR,
     TERNARY_EXPR,
@@ -648,6 +649,7 @@ public func IsExpr(node: *Node) : bool {
         case StmtKind.SET_EXPR:
         case StmtKind.SIZE_OF_EXPR:
         case StmtKind.STRING_EXPR:
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.SUBSCRIPT_GET_EXPR:
         case StmtKind.SUBSCRIPT_SET_EXPR:
         case StmtKind.TERNARY_EXPR:
@@ -863,6 +865,7 @@ public func (expr: *Expr) isConstExpr() : bool {
         case StmtKind.CHAR_EXPR:
         case StmtKind.IDENTIFIER_EXPR:
         case StmtKind.STRING_EXPR:
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.GET_EXPR: {
             return true
         }

--- a/src/ast_copy.lita
+++ b/src/ast_copy.lita
@@ -377,6 +377,7 @@ public func CopyExpr(expr: *Expr, module: *Module) : *Expr {
                                      module.allocator)
             return copy
         }
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.STRING_EXPR: {
             return expr // nothing to copy
         }

--- a/src/ast_new.lita
+++ b/src/ast_new.lita
@@ -643,6 +643,17 @@ public func NewStringExpr(startPos: SrcPos,
     return expr as (*Expr)
 }
 
+public func NewNativeStringExpr(startPos: SrcPos,
+                          endPos: SrcPos,
+                          string: Token,
+                          allocator: *const Allocator) : *Expr {
+    var expr = new<StringExpr>(allocator)
+    expr.kind = StmtKind.NATIVE_STRING_EXPR
+    expr.startPos = startPos
+    expr.endPos = endPos
+    expr.string = string
+    return expr as (*Expr)
+}
 
 public func NewCharExpr(startPos: SrcPos,
                           endPos: SrcPos,

--- a/src/cgen.lita
+++ b/src/cgen.lita
@@ -2470,13 +2470,27 @@ public func (this: using *CGen) emitStmt(s: *Stmt) {
             this.emitStrn(")", 1)
             return;
         }
+        case StmtKind.NATIVE_STRING_EXPR:
+            // fallthru
         case StmtKind.STRING_EXPR: {
             var expr = s as (*StringExpr)
 
-            if(expr.string.mod == Mod.MULTISTR) {
+            var length = 0
+            var start = 0
+            var end = 0
+
+            if(expr.string.mod & Mod.NATIVE_STRING) {
+                this.emitStrn("(", 1)
+                this.emitSymbol(expr.operand.typeInfo.sym)
+                this.emitStrn(")", 1)
+                this.emitStr(" { .buffer = ")
+            }
+
+            if(expr.string.mod & Mod.MULTISTR) {
                 var str = expr.string.str
 
                 this.buf.appendChar('"') // "
+                start = this.buf.length
                 for(var i = 0; i < str.length;) {
                     var byte = str.buffer[i] as (u8)
 
@@ -2527,12 +2541,29 @@ public func (this: using *CGen) emitStmt(s: *Stmt) {
                         i += len
                     }
                 }
+                end = this.buf.length
+
                 this.buf.appendChar('"') // "
             }
             else {
                 this.buf.appendStrn("\"", 1)
+                start = this.buf.length
+
                 this.buf.appendStrn(expr.string.str.buffer, expr.string.str.length)
+
+                end = this.buf.length
                 this.buf.appendStrn("\"", 1)
+            }
+
+            if(expr.string.mod & Mod.NATIVE_STRING) {
+                while(start < end) {
+                    var c = this.buf.buffer[start]
+                    if(c != '\\') {
+                        length += 1
+                    }
+                    start+=1
+                }
+                this.emit(", .length = %d }", length)
             }
             return;
         }

--- a/src/checker.lita
+++ b/src/checker.lita
@@ -471,6 +471,10 @@ func (this: *TypeChecker) createModuleSymbols(module: *Module) {
 
     module.flags |= ModuleFlags.TYPE_IMPORTED
 
+    if(module.flags & ModuleFlags.IS_BUILTIN) {
+        AssignBuiltinSymbols(module)
+    }
+
     for(var i = 0; i < module.ast.imports.size(); i += 1) {
         var imp = module.ast.imports.get(i)
         this.createImportSymbols(imp)
@@ -1800,6 +1804,7 @@ public func (this: *TypeChecker) resolveStmt(stmt: *Stmt) : bool {
         case StmtKind.SET_EXPR:
         case StmtKind.SIZE_OF_EXPR:
         case StmtKind.STRING_EXPR:
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.SUBSCRIPT_GET_EXPR:
         case StmtKind.SUBSCRIPT_SET_EXPR:
         case StmtKind.TERNARY_EXPR:

--- a/src/checker_expr.lita
+++ b/src/checker_expr.lita
@@ -102,6 +102,9 @@ public func (this: *TypeChecker) resolveExpr(expr: *Expr) : bool {
         case StmtKind.STRING_EXPR: {
             return this.resolveStringExpr(expr as (*StringExpr))
         }
+        case StmtKind.NATIVE_STRING_EXPR: {
+            return this.resolveNativeStringExpr(expr as (*StringExpr))
+        }
         case StmtKind.SUBSCRIPT_GET_EXPR: {
             return this.resolveSubscriptGetExpr(expr as (*SubscriptGetExpr))
         }
@@ -1044,6 +1047,15 @@ func (this: *TypeChecker) resolveNumberExpr(expr: *NumberExpr) : bool {
 func (this: *TypeChecker) resolveStringExpr(expr: *StringExpr) : bool {
     assert(expr != null)
     expr.operand.typeInfo = &STR_TYPE
+    expr.operand.isConst = true
+    expr.operand.isRightValue = true
+    expr.operand.val = expr.string.value
+    return true
+}
+
+func (this: *TypeChecker) resolveNativeStringExpr(expr: *StringExpr) : bool {
+    assert(expr != null)
+    expr.operand.typeInfo = stringBuiltin.type
     expr.operand.isConst = true
     expr.operand.isRightValue = true
     expr.operand.val = expr.string.value

--- a/src/generics.lita
+++ b/src/generics.lita
@@ -897,6 +897,9 @@ func ReplaceTypes(template: *Template, ast: *Node) : bool {
             ReplaceTypes(template, expr.sizeOfExpr)
             break;
         }
+        case StmtKind.NATIVE_STRING_EXPR: {
+            break;
+        }
         case StmtKind.STRING_EXPR: {
             break;
         }

--- a/src/intern.lita
+++ b/src/intern.lita
@@ -83,6 +83,9 @@ public const ASSTR = InternedString{};
 public const TOSTR = InternedString{};
 public const COMPILER_OPTION = InternedString{};
 
+// built-ins
+public const STRING_TYPE = InternedString{};
+public const ANY_TYPE = InternedString{};
 
 public func InternMap<V>(emptyValue: V,
                          initialSize: i32 = 16,
@@ -170,6 +173,10 @@ public func (this: *Strings) init(allocator: *const Allocator) {
     this.internConstant("asStr", 5, &ASSTR)
     this.internConstant("toStr", 5, &TOSTR)
     this.internConstant("compiler_option", 15, &COMPILER_OPTION)
+
+    // built-in types
+    this.internConstant("String", 6, &STRING_TYPE)
+    this.internConstant("any", 3, &ANY_TYPE)
 
 }
 

--- a/src/lex.lita
+++ b/src/lex.lita
@@ -85,6 +85,7 @@ public enum TokenType {
     COLON,
     COLON_COLON,
     DOUBLE_QUOTE,
+    DOLLAR_QUOTE,
 
     LESS_THAN,
     LESS_EQUALS,
@@ -209,6 +210,7 @@ public const tokenText = [TokenType.MAX_TOKEN_TYPES]*const char {
     [TokenType.COLON] = ":",
     [TokenType.COLON_COLON] = "::",
     [TokenType.DOUBLE_QUOTE] = "\"",
+    [TokenType.DOLLAR_QUOTE] = "$\"",
 
     [TokenType.LESS_THAN] = "<",
     [TokenType.LESS_EQUALS] = "<=",
@@ -451,8 +453,9 @@ public union Value {
 }
 
 public enum Mod {
-    NONE = 0,
-    MULTISTR,
+    NONE            = 0,
+    MULTISTR        = (1<<1),
+    NATIVE_STRING   = (1<<2),
 }
 
 public struct Token {
@@ -1166,7 +1169,7 @@ func (l: *Lexer) validateCodepoint(str: *const char, len: i32) : bool {
     return true
 }
 
-func (l: *Lexer) scanString() : Token {
+func (l: *Lexer) scanString(isNative: bool) : Token {
     var isVerbatim = false
     var isValid = true
     var startPos: *const char = null
@@ -1275,13 +1278,13 @@ func (l: *Lexer) scanString() : Token {
 
     l.token.type = TokenType.STRING
     l.token.pos.end = l.stream
+    l.token.mod = isNative ? Mod.NATIVE_STRING : Mod.NONE
     if(isVerbatim) {
         l.token.value.str.length = ((l.stream - startPos) - 3) as (i32)
-        l.token.mod = Mod.MULTISTR
+        l.token.mod |= Mod.MULTISTR
     }
     else {
         l.token.value.str.length = ((l.stream - startPos) - 1) as (i32)
-        l.token.mod = Mod.NONE
     }
 
     return isValid ? l.token : l.errorToken()
@@ -1333,6 +1336,10 @@ func (l: *Lexer) scanSymbol() : Token {
         }
         case '$': {
             l.token.type = TokenType.DOLLAR
+            if(l.stream[0] == '"') {
+                l.nextChar()
+                l.token.type = TokenType.DOLLAR_QUOTE
+            }
             break;
         }
         case '#': {
@@ -1543,7 +1550,14 @@ repeat:
             goto repeat;
         }
         case '"': { // "
-            return l.scanString()
+            return l.scanString(.isNative = false)
+        }
+        case '$': {
+            if(l.stream[1] != '"') {
+                return l.scanSymbol()
+            }
+            l.nextChar() // eat the $
+            return l.scanString(.isNative = true)
         }
         case '\'': {
             return l.scanChar()

--- a/src/lsp/util.lita
+++ b/src/lsp/util.lita
@@ -859,6 +859,7 @@ func (this: *SourceLookup) visitExpr(node: *Expr) : bool {
         case StmtKind.NULL_EXPR:
         case StmtKind.NUMBER_EXPR:
         case StmtKind.STRING_EXPR:
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.CHAR_EXPR:
         case StmtKind.BOOLEAN_EXPR:
         case StmtKind.POISON_EXPR: {

--- a/src/module.lita
+++ b/src/module.lita
@@ -8,6 +8,7 @@ import "std/system"
 import "std/libc"
 import "std/mem"
 import "std/mem/arena_allocator"
+import "std/assert"
 
 import "phase_result"
 import "symbols"
@@ -25,6 +26,7 @@ public enum ModuleFlags {
     TYPE_IMPORTED = (1<<2),
 
     INCREMENTAL_COMPILATION = (1<<3),
+    IS_BUILTIN    = (1<<4),
 }
 
 public struct ModuleId {
@@ -73,6 +75,10 @@ public const BUILTIN_IMPORT_TOKEN = Token {
         }
     }
 }
+
+public var anyBuiltin: *Symbol = null
+public var stringBuiltin: *Symbol = null
+
 public const builtins = Module{}
 public func BuiltinsInit(lita: *Lita) : *Module {
     BUILTIN_IMPORT_IDENT.str = BUILTIN
@@ -80,7 +86,7 @@ public func BuiltinsInit(lita: *Lita) : *Module {
 
     builtins.text = StringBuffer{}
     builtins.ast = null
-    builtins.flags = 0
+    builtins.flags = ModuleFlags.IS_BUILTIN
     builtins.allocator = lita.allocator
     builtins.importedBy = StrMap<ModuleImport>(ModuleImport{}, 512, lita.allocator)
     builtins.symbols.init(ScopeKind.MODULE, null, lita.result, &builtins, lita.allocator)
@@ -111,6 +117,16 @@ public func BuiltinsInit(lita: *Lita) : *Module {
     AddBuiltin(lita, &VOID_TYPE)
 
     return &builtins
+}
+
+public func AssignBuiltinSymbols(module: *Module) {
+    assert(module != null)
+
+    stringBuiltin = module.getType(STRING_TYPE)
+    assert(stringBuiltin != null)
+
+    anyBuiltin = module.getType(ANY_TYPE)
+    assert(anyBuiltin != null)
 }
 
 func AddBuiltin(lita: *Lita, type: *TypeInfo) {

--- a/src/parser.lita
+++ b/src/parser.lita
@@ -1340,6 +1340,9 @@ func (p: *Parser) primary() : *Expr {
     }
 
     if(p.match(TokenType.STRING)) {
+        if(token.mod & Mod.NATIVE_STRING) {
+            return NewNativeStringExpr(pos, p.pos(), token, p.allocator)
+        }
         return NewStringExpr(pos, p.pos(), token, p.allocator)
     }
 
@@ -2948,6 +2951,7 @@ func (p: *Parser) checkConstExpr(expr: *Expr) : bool {
         case StmtKind.NUMBER_EXPR:
         case StmtKind.BOOLEAN_EXPR:
         case StmtKind.STRING_EXPR:
+        case StmtKind.NATIVE_STRING_EXPR:
         case StmtKind.CHAR_EXPR:
         case StmtKind.NULL_EXPR:
         case StmtKind.IDENTIFIER_EXPR:

--- a/stdlib/std/assert.lita
+++ b/stdlib/std/assert.lita
@@ -65,6 +65,23 @@ public func assertFloat<F>(
     }
 }
 
+public func assertEq<N>(
+    expected: N,
+    actual: N,
+    filename: *const char = __FILE__,
+    lineNumber: usize = __LINE__): void {
+
+    if(expected != actual) {
+        fprintf(stderr, "%s:%zu: Assertion failed: expected: '%d' to equal actual: '%d'\n",
+            filename,
+            lineNumber,
+            expected,
+            actual
+        )
+        bort()
+    }
+}
+
 @test
 func testAssertEqualsStr() {
     assertStr("x", "x")

--- a/stdlib/std/builtins.lita
+++ b/stdlib/std/builtins.lita
@@ -5,6 +5,11 @@ public struct any {
     id: typeid
 }
 
+public struct String {
+    buffer: *const char
+    length: i32
+}
+
 /**
 ========================================================================
 Note declarations

--- a/stdlib/std/json/from_json.lita
+++ b/stdlib/std/json/from_json.lita
@@ -206,7 +206,7 @@ public func (this: *Map<K, V>) fromJson<K, V>(context: *JsonContext, json: *Json
         var value = StringBufferInit(clonedStr, str.length, str.length)
         this.put<K,V>(entry.key, value)
 
-#elseif json_check_generic_symbol("this", "V", "std::string::String")
+#elseif json_check_generic_symbol("this", "V", "std::builtins::String")
         var str = StringInit(entry.value.asString())
 
         var clonedStr = StringClone(str.buffer, str.length, context.allocator)
@@ -272,7 +272,7 @@ public func (this: *Array<T>) fromJson<T>(context: *JsonContext, json: *JsonNode
         var value = StringBufferInit(clonedStr, str.length, str.length)
         this.add(value)
 
-#elseif json_check_generic_symbol("this", "T", "std::string::String")
+#elseif json_check_generic_symbol("this", "T", "std::builtins::String")
         var str = StringInit(element.asString())
 
         var clonedStr = StringClone(str.buffer, str.length, context.allocator)

--- a/stdlib/std/json/json.lita
+++ b/stdlib/std/json/json.lita
@@ -1265,6 +1265,9 @@ func (p: using *JsonParser) scanMultiStr() {
                 if(*stream == '`') {
                     val = '`'
                     stream += 1
+                } else if(*stream == '\\') {
+                    val = '\\'
+                    stream += 1
                 } else {
                     buffer.append("%c", val)
                     val = *stream

--- a/stdlib/std/string/string.lita
+++ b/stdlib/std/string/string.lita
@@ -3,10 +3,11 @@ import "std/mem" as mem
 import "std/assert"
 
 
-public struct String {
-    buffer: *const char
-    length: i32
-}
+// Defined in builtin.lita
+// public struct String {
+//     buffer: *const char
+//     length: i32
+// }
 
 public func StringInit(buffer: *const char, length: i32 = -1) : String {
     if(buffer == null) {

--- a/test/tests/strings.json
+++ b/test/tests/strings.json
@@ -19,13 +19,234 @@
     `,
     "tests": [
         {
+            "name" : "Native Strings",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $"Hello World"
+                assert(s.buffer.equals("Hello World"))
+                assert(s.equals($"Hello World"))
+                assert(s.length == s.buffer.length())
+            `,
+        },
+        {
+            "name" : "Native Strings With Escapes",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $"Hello\"World"
+                assert(s.buffer.equals("Hello\"World"))
+                assert(s.equals($"Hello\"World"))
+                assert(s.length == s.buffer.length())
+            `,
+        },
+        {
+            "name" : "Native Strings Verbatim",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $"""Hello World
+"""
+                assert(s.equals($"Hello World\n"))
+                assert(s.buffer.equals("Hello World\n"))
+                assert(s.length == s.buffer.length())
+            `,
+        },
+        {
+            "name" : "Native Strings Pass",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = String { .buffer = "H", .length = 1 }.length
+                assert(s == 1)
+                var sx = String { .buffer = "H", .length = 1 }.buffer
+                assert(sx.equals("H"))
+                var str = String { .buffer = "H", .length = 1 }
+                assert(str.equals(String { .buffer = "H", .length = 1 }))
+            `,
+        },
+        {
+            "name" : "Native Strings Pass using syntax",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $"H".length
+                assert(s == 1)
+                var sx = $"H".buffer
+                assert(sx.equals("H"))
+                var str = $"H"
+                assert(str.equals(String { .buffer = "H", .length = 1 }))
+                assert(str.equals($"H"))
+                assert($"H".equals($"H"))
+            `,
+        },
+        {
+            "name" : "Native Strings Index",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $"H"[0]
+            `,
+            "error": "invalid index into 'String'"
+        },
+        {
+            "name" : "Native Strings With Invalid Start",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var s = $ "Hello\"World"
+                assert(s.equals("Hello\"World"))
+            `,
+            "error": "Unexpected token"
+        },
+        {
+            "name" : "Native Strings With Default Args Constructor",
+            "definitions": `
+                import "std/string"
+
+                struct X {
+                    s: String = $"Hello"
+                }
+            `,
+            "code": `
+                var x = X{}
+                assert(x.s.equals($"Hello"))
+            `,
+        },
+        {
+            "name" : "Native Strings With Default Args Function",
+            "definitions": `
+                import "std/string"
+
+                func TestX(s: String = $"Hello") : String {
+                    return s
+                }
+            `,
+            "code": `
+                var x = TestX()
+                assert(x.equals($"Hello"))
+
+                var y = TestX($"World")
+                assert(y.equals($"World"))
+            `,
+        },
+        {
+            "name" : "Native Strings Function Returns",
+            "definitions": `
+                import "std/string"
+
+                func TestX(s: String = $"Hello") : String {
+                    return s
+                }
+
+                func TestY() : String {
+                    return $"Hello"
+                }
+            `,
+            "code": `
+                var x = TestX().buffer
+                assert(x.equals("Hello"))
+
+                var y = TestX($"World").length
+                assert(y == 5)
+
+                var z = TestY()
+                assert(z.equals($"Hello"))
+
+                var w = TestY().buffer
+                assert(w.equals("Hello"))
+            `,
+        },
+        {
+            "name" : "Native Strings Assignment",
+            "definitions": `
+                import "std/string"
+
+            `,
+            "code": `
+                var x: String = $"H"
+                var y = x
+                y = $"W"
+
+                assert(x.equals($"H"))
+                assert(y.equals($"W"))
+            `,
+        },
+        {
+            "name" : "Native Strings Generics",
+            "definitions": `
+                import "std/string"
+
+                struct X<T> {
+                    s: String
+                    x: T
+                }
+            `,
+            "code": `
+                var x = X {
+                    .s = $"H",
+                    .x = $"W"
+                }
+
+                assert(x.s.equals($"H"))
+                assert(x.x.equals($"W"))
+            `,
+        },
+        {
+            "name" : "Native Strings Array",
+            "definitions": `
+                import "std/string"
+
+            `,
+            "code": `
+                var x = []String {
+                    $"H", $"W"
+                }
+
+                assert(x[0].equals($"H"))
+                assert(x[1].equals($"W"))
+            `,
+        },
+        {
+            "name" : "Native Strings Length",
+            "definitions": `
+                import "std/string"
+
+            `,
+            "code": `
+                var x = $"\r\n\""
+
+                assert(x.length == 3)
+                assert(x.length == x.buffer.length())
+            `,
+        },
+        {
+            "name" : "Native Strings Length Emoji",
+            "definitions": `
+                import "std/string"
+            `,
+            "code": `
+                var x = $"✅"
+
+                assert(x.length == 3)
+                assert(x.length == x.buffer.length())
+            `,
+        },
+        {
             "name": "Verbatim String with escape chars",
             "definitions": `
 
             `,
             "code": `
                 var str = """this\nis\there"from"""
-                assert(strcmp("this\\nis\\there\"from", str) == 0)
+                assert(strcmp("this\\\nis\\\there\"from", str) == 0)
             `,
         },
         {


### PR DESCRIPTION
Add `native` string support for converting to `String` type from string literals

```
var x: String = $"Hello"
assert(x.length == 5)
assert(x.buffer.equals("Hello"))
```